### PR TITLE
chore: add dependabot config for bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml`
- configure Dependabot version 2
- enable weekly Bundler updates for the repository root (`/`)

## Why
- this repository uses `Gemfile` and `Gemfile.lock`
- Dependabot needs explicit ecosystem configuration to open dependency update PRs
