### PR TITLE
chore: fix remove medium blog nav

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,13 +1,9 @@
 main:
   - title: "Blog"
-    url: https://medium.com/@hossainshabib
-    target: "_blank"
+    url: /posts/
   - title: "LinkedIn"
     url: https://www.linkedin.com/in/ahmadshabibulhossain
     target: "_blank"
   - title: "GitHub"
     url: https://github.com/shabib87
-    target: "_blank"
-  - title: "Archive"
-    url: /posts/
     target: "_blank"

--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -1,4 +1,4 @@
 en:
-  recent_posts: "Archived Posts"
+  recent_posts: "Latest Posts"
 en-CA:
-  recent_posts: "Archived Posts"
+  recent_posts: "Latest Posts"

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -22,7 +22,7 @@ This blog is where I write about these experiences and philosophies. Here, I wri
 ## Quick Links
 
 - 📩 <a href="mailto:ahmad@codewithshabib.com">Contact me</a>
-- 🧠 <a href="https://medium.com/@hossainshabib" target="_blank" rel="noopener">Browse the blog</a>
+- 🧠 <a href="/posts/">Browse the blog</a>
 - 🔗 <a href="https://github.com/shabib87" target="_blank" rel="noopener">GitHub</a>
 - 🔗 <a href="https://www.linkedin.com/in/ahmadshabibulhossain" target="_blank" rel="noopener">LinkedIn</a>
 

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -1,11 +1,11 @@
 ---
-title: "Archived Blog"
+title: "Blog"
 tagline: "Principal-level insights on mobile system design, debugging, architecture, and engineering leadership—real stories from the field."
 permalink: /posts/
 layout: home
 author_profile: true
 entries_layout: grid
-entries_title: "Archived Posts"
+entries_title: "Latest Posts"
 classes: wide
 description: "Principal-level insights on mobile system design, debugging, architecture, and engineering leadership—real stories from the field."
 ---


### PR DESCRIPTION
## Summary

- fix remove medium blog nav

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Validation

- `make check`

## Affected Files

```text
_data/navigation.yml
_data/ui-text.yml
_pages/about.md
_pages/posts.md
```

## Affected URLs

```text
/
/posts/
```

## Self-review Notes

- Local checks passed
- Diff reviewed
- No private drafts or secrets included
