### PR TITLE
feat: codex workflow and site qa hardening

### DIFF
--- a/.agents/skills/official-doc-verifier/SKILL.md
+++ b/.agents/skills/official-doc-verifier/SKILL.md
@@ -9,9 +9,14 @@ Use this skill when memory is not enough.
 
 ## Workflow
 
-1. Prefer Context7 when the official docs are available there.
-2. Fall back to first-party docs when Context7 is not the right source.
-3. Summarize the confirmed behavior before encoding it in code, docs, or publishing guidance.
+1. Read `references/approved-sources.md`.
+2. Read `references/context7-lookup.md` when the docs are likely to be available in Context7.
+3. Read `references/research-sequencing.md` when the answer will affect code, docs, or workflow behavior.
+4. Check repo-local truth before leaving the workspace.
+5. Prefer Context7 when the official docs are available there.
+6. Fall back to first-party docs when Context7 is not the right source.
+7. Use general web search only when repo-local truth, Context7, and first-party docs still do not answer the question.
+8. Summarize the confirmed behavior before encoding it in code, docs, or publishing guidance.
 
 ## Output Expectations
 
@@ -27,6 +32,9 @@ Use this skill when memory is not enough.
 ## Rules
 
 - Prefer official docs over memory for version-sensitive behavior.
+- Check the repo first for repo-owned truth before leaving the workspace.
 - Use Context7 first when the official docs are available there.
 - Fall back to first-party docs when Context7 is not the right source.
+- Use narrow, behavior-specific queries instead of topic-level lookups.
+- State the implementation impact, not only the citation result.
 - Summarize the conclusion when it affects implementation or published guidance.

--- a/.agents/skills/official-doc-verifier/references/context7-lookup.md
+++ b/.agents/skills/official-doc-verifier/references/context7-lookup.md
@@ -1,0 +1,8 @@
+# Context7 Lookup
+
+- Resolve the exact product or library before querying docs.
+- Ask behavior questions, not topic questions.
+- Include the affected tool, feature, and operation in the query.
+- Include version context when the user already supplied it.
+- Prefer one precise query over a broad exploratory query when the behavior is already known.
+- Use the returned docs to answer the implementation question directly.

--- a/.agents/skills/official-doc-verifier/references/research-sequencing.md
+++ b/.agents/skills/official-doc-verifier/references/research-sequencing.md
@@ -1,0 +1,7 @@
+# Research Sequencing
+
+1. Check the repo for the current local contract.
+2. Check Context7 for official product or library behavior.
+3. Check first-party docs when Context7 is not the right source.
+4. Use general web search only when the first three steps do not answer the question.
+5. Summarize the confirmed behavior and its implementation impact before editing code or docs.

--- a/.agents/skills/repo-flow/SKILL.md
+++ b/.agents/skills/repo-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-flow
-description: Standardize git, validation, PR, and merge workflow for this repository. Use when starting new work, running repo checks, preparing a pull request, finalizing a merge, or aligning work with the repo's linear-history policy.
+description: Standardize git, validation, PR, and rebase-only integration workflow for this repository. Use when starting new work, running repo checks, preparing a pull request, finalizing rebase integration, or aligning work with the repo's trunk-based development policy.
 ---
 
 # Repo Flow
@@ -12,24 +12,27 @@ Use this skill for repo mechanics.
 1. Read `references/branch-pr-merge.md`.
 2. Read `references/context7-verification.md` when command behavior depends on official docs.
 3. Use the scripts in this skill and the repo root `scripts/` commands instead of ad hoc git/gh sequences.
+4. Require `make qa-local` before commit, before PR creation, and again on the committed tree before push or rebase integration.
 
 ## Output Expectations
 
 - clean branch creation
 - consistent PR title/body
 - local-first validation before PR
-- solo self-review merge flow
+- solo self-review rebase integration flow
 
 ## Done Criteria
 
 - the work is packaged in a PR with clean commits
 - local checks passed
-- the merge path is explicit and safe for a solo maintainer
+- the rebase-only integration path is explicit and safe for a solo maintainer
 
 ## Rules
 
 - Start repo-changing work from `main` on a fresh `codex/*` branch.
+- Do not commit until the full local QA gate passes.
+- Re-run the same local QA gate on the committed tree before push or rebase integration.
 - Run local checks before opening a PR.
-- Require valid `gh` authentication for PR and merge commands.
-- Keep history linear and prefer rebase-based merge behavior.
+- Require valid `gh` authentication for PR and rebase integration commands.
+- Keep history linear and prefer rebase-only integration behavior.
 - Do not require external reviewer approval for this repo; require explicit self-review instead.

--- a/.agents/skills/repo-flow/agents/openai.yaml
+++ b/.agents/skills/repo-flow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Repo Flow"
-  short_description: "Run the repo's branch, PR, and merge workflow"
+  short_description: "Run the repo's branch, PR, and rebase-only workflow"
   default_prompt: "Use $repo-flow to start work, validate changes, and prepare the PR for this repository."

--- a/.agents/skills/repo-flow/references/branch-pr-merge.md
+++ b/.agents/skills/repo-flow/references/branch-pr-merge.md
@@ -1,20 +1,23 @@
-# Branch, PR, And Merge
+# Branch, PR, And Rebase Integration
 
 ## Branches
 
 - start from `main`
 - create a `codex/<type>-<slug>` branch
 - keep work isolated to that branch
+- do not commit until `make qa-local` passes
+- if site-facing files changed, preview with `bundle exec jekyll serve` before commit
 
 ## PRs
 
-- run local checks before creating the PR
+- run `make qa-local` before creating the PR
+- keep the working tree clean before PR creation
 - use Conventional Commit style for the PR title
 - include summary, why, validation, affected files, affected URLs, and self-review notes
 
-## Merge
+## Integration
 
-- require local checks and explicit self-review
+- require `make qa-local` on the committed tree and explicit self-review
 - if CI has reported, require it to be green
-- prefer rebase-style merge behavior for a linear history
-- delete the branch after merge
+- integrate with rebase only for a linear history
+- delete the branch after integration

--- a/.agents/skills/site-quality-auditor/SKILL.md
+++ b/.agents/skills/site-quality-auditor/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: site-quality-auditor
+description: Audit this Jekyll site for source-level SEO, performance, quality, and maintainability issues. Use when reviewing website changes, validating page metadata, checking archive and about pages, inspecting structured data and head tags, or hardening the repo's site QA workflow before commit or PR.
+---
+
+# Site Quality Auditor
+
+Use this skill for repo-specific website maintenance and QA.
+
+## Workflow
+
+1. Read `references/quality.md`.
+2. Read the mode-specific reference for the requested audit:
+   `references/seo.md`, `references/performance.md`, or `references/maintenance.md`.
+3. Start from repo-local truth:
+   `_config.yml`, `_includes/head/custom.html`, `_includes/json-ld.html`, `_pages/`, and the affected file paths.
+4. Use `make site-audit AUDIT=<mode> TARGET=<target>` when deterministic repo-local checks will reduce guesswork.
+5. Use `official-doc-verifier` when current Codex, Jekyll, Minimal Mistakes, or other official behavior matters.
+6. If the audit leads to repo changes, follow `repo-flow` and require `make qa-local` before commit.
+
+## Modes
+
+- `seo`
+- `performance`
+- `quality`
+- `maintenance`
+
+## Output Expectations
+
+- findings grouped by severity
+- affected files or templates
+- recommended next step
+- explicit follow-up checks when manual preview is still required
+
+## Done Criteria
+
+- the audit is grounded in the actual repo files
+- the result separates source-level facts from manual follow-up
+- the next action is clear: fix, preview, verify docs, or continue through repo QA
+
+## Rules
+
+- Stay source-first. Do not pretend a live-site or browser audit happened if it did not.
+- Treat `_config.yml`, `_includes/head/custom.html`, and `_includes/json-ld.html` as primary SEO and metadata surfaces.
+- Prefer repo-specific findings over generic web advice.
+- Do not replace editorial skills. Hand drafting, fact-checking, and publication work back to the editorial pipeline.

--- a/.agents/skills/site-quality-auditor/agents/openai.yaml
+++ b/.agents/skills/site-quality-auditor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Site Quality Auditor"
+  short_description: "Review this Jekyll site for SEO, quality, and maintenance issues"
+  default_prompt: "Use $site-quality-auditor to review this change for site SEO, quality, performance, or maintenance issues."

--- a/.agents/skills/site-quality-auditor/references/maintenance.md
+++ b/.agents/skills/site-quality-auditor/references/maintenance.md
@@ -1,0 +1,7 @@
+# Maintenance Audit Notes
+
+- Check for remote dependencies that can make builds or checks brittle.
+- Check repo workflow drift between Make targets, scripts, skills, prompts, and docs.
+- Flag third-party scripts or assets that deserve periodic review.
+- Note when a repo command depends on network access or cached state.
+- Hand version-sensitive behavior to `official-doc-verifier` instead of guessing.

--- a/.agents/skills/site-quality-auditor/references/performance.md
+++ b/.agents/skills/site-quality-auditor/references/performance.md
@@ -1,0 +1,7 @@
+# Performance Audit Notes
+
+- Stay source-level unless the user explicitly asks for browser or lab tooling.
+- Review global scripts and third-party assets first.
+- Call out assets or scripts that load on every page.
+- Flag obviously large local image assets when they are likely to affect page weight.
+- Distinguish between confirmed source issues and performance hypotheses that need live measurement.

--- a/.agents/skills/site-quality-auditor/references/quality.md
+++ b/.agents/skills/site-quality-auditor/references/quality.md
@@ -1,0 +1,6 @@
+# Quality Audit Notes
+
+- Review `_config.yml`, shared head includes, archive pages, homepage or about page, and 404 behavior before drilling into individual files.
+- Validate front matter presence, `title`, `description`, `layout`, and indexing-related fields.
+- Surface manual preview requirements when site-facing files changed.
+- Treat broken repo workflow guidance as a quality issue when it affects safe release flow.

--- a/.agents/skills/site-quality-auditor/references/seo.md
+++ b/.agents/skills/site-quality-auditor/references/seo.md
@@ -1,0 +1,7 @@
+# SEO Audit Notes
+
+- Check `_config.yml` for `jekyll-seo-tag`, `jekyll-sitemap`, `url`, and site metadata.
+- Check `_includes/head/custom.html` for `{% seo %}`, canonical metadata surface, Open Graph tags, Twitter tags, and JSON-LD inclusion.
+- Check `_includes/json-ld.html` for `schema.org` context and the current article schema shape.
+- Check target pages for `title`, `description`, `permalink`, and any `robots` or `sitemap` overrides.
+- Treat duplicate metadata in custom head overrides as a finding worth surfacing.

--- a/.codex/docs/README.md
+++ b/.codex/docs/README.md
@@ -4,12 +4,15 @@
 
 1. Run `make setup`
    This bootstraps the repo-managed tooling environment and installs git hooks.
-2. Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=feat`
-3. Use a repo-local skill or a repo-scoped slash command from `.codex/prompts/`
-4. Run editorial validation or `make site-audit` for site maintenance work
-5. Run `make qa-local`
-6. Create the PR with `make create-pr TYPE=feat`
-7. Self-review and integrate with `make finalize-merge PR=...`
+2. Open the repo in the Codex IDE extension or the Codex app.
+3. In VS Code or Cursor, start with one of these repo workflow prompt files:
+   - `@.codex/prompts/site-workflow.md`
+   - `@.codex/prompts/editorial-workflow.md`
+   - `@.codex/prompts/medium-to-blog.md`
+4. In the Codex app, start with the equivalent `$skills` prompt from
+   [Codex Usage](./codex-usage.md).
+5. Let Codex use the repo skills and `make` targets for validation, publication, and PR flow.
+6. Finish with the repo flow and PR creation.
 
 ## Docs Index
 

--- a/.codex/docs/README.md
+++ b/.codex/docs/README.md
@@ -4,18 +4,19 @@
 
 1. Run `make setup`
    This bootstraps the repo-managed tooling environment and installs git hooks.
-2. Create or edit a private draft in `_drafts/`
-3. Run `make validate-draft PATH=_drafts/your-post.md`
-4. Run `make qa-publish PATH=_drafts/your-post.md`
-5. Run `make publish-draft PATH=_drafts/your-post.md DATE=YYYY-MM-DD`
-6. Run `make check`
-7. Create the PR with `make create-pr TYPE=feat`
-8. Self-review and merge with `make finalize-merge PR=...`
+2. Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=feat`
+3. Use a repo-local skill or a repo-scoped slash command from `.codex/prompts/`
+4. Run editorial validation or `make site-audit` for site maintenance work
+5. Run `make qa-local`
+6. Create the PR with `make create-pr TYPE=feat`
+7. Self-review and integrate with `make finalize-merge PR=...`
 
 ## Docs Index
 
 - [AI Workflow](./ai-workflow.md)
+- [Codex Usage](./codex-usage.md)
 - [Editorial Policy](./editorial-policy.md)
+- [Site Quality](./site-quality.md)
 - [Tooling](./tooling.md)
 - [Workflows](./workflows.md)
 - [Prompt Recipes](./prompt-recipes.md)
@@ -29,3 +30,4 @@
 - `medium-porter`
 - `repo-flow`
 - `official-doc-verifier`
+- `site-quality-auditor`

--- a/.codex/docs/ai-workflow.md
+++ b/.codex/docs/ai-workflow.md
@@ -3,8 +3,9 @@
 ## Purpose
 
 This repository stores its AI workflow in version control. The root `AGENTS.md`, the
-repo-local skills under `.agents/skills/`, and the helper commands in `Makefile` and `scripts/`
-are the canonical source of truth for how Codex should work in this repo.
+repo-local skills under `.agents/skills/`, the repo-scoped slash commands under `.codex/prompts/`,
+and the helper commands in `Makefile` and `scripts/` are the canonical source of truth for how
+Codex should work in this repo.
 
 ## Draft Privacy
 
@@ -18,15 +19,22 @@ are the canonical source of truth for how Codex should work in this repo.
 - Required on the machine: Ruby `3.4.4`, Git, and Homebrew
 - `make setup` bootstraps Bundler, installs repo-managed `pre-commit` into `.venv-tools/`,
   installs git hooks, and installs gems into `vendor/bundle`
-- GitHub CLI is only required for PR creation and merge commands
-- Valid GitHub CLI authentication is required for PR and merge commands:
+- GitHub CLI is only required for PR creation and rebase-only integration commands
+- Valid GitHub CLI authentication is required for PR and integration commands:
 
 ```bash
 gh auth login -h github.com
 ```
 
 SSH is sufficient for `git push`, but it is not sufficient for `gh pr create` or
-`gh pr merge`.
+`gh pr merge --rebase`.
+
+## Workflow Starters
+
+- Use repo-local skills for reusable repo-specific workflows.
+- Use repo-scoped slash commands from `.codex/prompts/` for short workflow starters.
+- Use `make` targets for deterministic repo mechanics and validation.
+- This repo follows trunk-based development and integrates changes with rebase only.
 
 ## Standard Flow
 
@@ -36,42 +44,57 @@ SSH is sufficient for `git push`, but it is not sufficient for `gh pr create` or
    make start-work TOPIC="describe the work" TYPE=feat
    ```
 
-2. Create or refine a private draft in `_drafts/`.
-3. Validate the draft:
+2. Use a repo-local skill or repo-scoped slash command to start the right workflow.
+3. Create or refine a private draft in `_drafts/` when the work is editorial.
+4. Validate the draft:
 
    ```bash
    make validate-draft PATH=_drafts/your-post.md
    ```
 
-4. Run publish QA:
+5. Run publish QA:
 
    ```bash
    make qa-publish PATH=_drafts/your-post.md
    ```
 
-5. Publish the draft:
+6. Publish the draft:
 
    ```bash
    make publish-draft PATH=_drafts/your-post.md DATE=YYYY-MM-DD
    ```
 
-6. Run tracked repo validation:
+7. Run site audits as needed:
 
    ```bash
-   make check
+   make site-audit AUDIT=seo TARGET=site
+   make site-audit AUDIT=quality TARGET=site
    ```
 
-7. Create the PR:
+8. Run the full local QA gate:
+
+   ```bash
+   make qa-local
+   ```
+
+9. Create the PR:
 
    ```bash
    make create-pr TYPE=feat
    ```
 
-8. Finalize the solo self-review merge:
+10. Finalize the solo self-review integration:
 
    ```bash
    make finalize-merge PR=123
    ```
+
+## Release Rules
+
+- Do not commit until `make qa-local` passes.
+- Re-run `make qa-local` on the committed tree before push or rebase integration.
+- If a change touches `_config.yml`, `_includes/`, `_layouts/`, `_pages/`, `_posts/`, `assets/`,
+  or `_sass/`, preview locally with `bundle exec jekyll serve` before commit.
 
 ## Repo-Local Skills
 
@@ -79,8 +102,9 @@ SSH is sufficient for `git push`, but it is not sufficient for `gh pr create` or
 - `content-brainstormer`: Topic ideation and editorial backlog development
 - `fact-checker`: Primary-source verification for technical claims
 - `medium-porter`: Medium-to-Jekyll migration and normalization
-- `repo-flow`: Branch, PR, and merge mechanics
+- `repo-flow`: Branch, PR, and rebase-only integration mechanics
 - `official-doc-verifier`: Context7 and primary-doc confirmation for version-sensitive details
+- `site-quality-auditor`: Site SEO, quality, performance, and maintenance reviews
 
 ## Verification Expectations
 
@@ -90,3 +114,9 @@ SSH is sufficient for `git push`, but it is not sufficient for `gh pr create` or
 - Use repo-local files for repo-specific truth before consulting outside docs.
 - Keep workflow scripts deterministic and lightweight. Put policies in docs or skill references,
   not in opaque shell behavior.
+- Use the release gate explicitly:
+
+   ```bash
+   make qa-local
+   make check
+   ```

--- a/.codex/docs/ai-workflow.md
+++ b/.codex/docs/ai-workflow.md
@@ -3,9 +3,9 @@
 ## Purpose
 
 This repository stores its AI workflow in version control. The root `AGENTS.md`, the
-repo-local skills under `.agents/skills/`, the repo-scoped slash commands under `.codex/prompts/`,
-and the helper commands in `Makefile` and `scripts/` are the canonical source of truth for how
-Codex should work in this repo.
+repo-local skills under `.agents/skills/`, the repo workflow prompt files under
+`.codex/prompts/`, and the helper commands in `Makefile` and `scripts/` are the canonical source
+of truth for how Codex should work in this repo.
 
 ## Draft Privacy
 
@@ -32,7 +32,9 @@ SSH is sufficient for `git push`, but it is not sufficient for `gh pr create` or
 ## Workflow Starters
 
 - Use repo-local skills for reusable repo-specific workflows.
-- Use repo-scoped slash commands from `.codex/prompts/` for short workflow starters.
+- In VS Code or Cursor, use repo workflow prompt files from `.codex/prompts/` via
+  `@.codex/prompts/<workflow>.md`.
+- In the Codex app, use explicit `$skills` prompts for the same workflows.
 - Use `make` targets for deterministic repo mechanics and validation.
 - This repo follows trunk-based development and integrates changes with rebase only.
 
@@ -44,7 +46,8 @@ SSH is sufficient for `git push`, but it is not sufficient for `gh pr create` or
    make start-work TOPIC="describe the work" TYPE=feat
    ```
 
-2. Use a repo-local skill or repo-scoped slash command to start the right workflow.
+2. Use a repo-local skill, a repo workflow prompt file, or an explicit multi-skill prompt to
+   start the right workflow.
 3. Create or refine a private draft in `_drafts/` when the work is editorial.
 4. Validate the draft:
 

--- a/.codex/docs/codex-usage.md
+++ b/.codex/docs/codex-usage.md
@@ -1,0 +1,74 @@
+# Codex Usage
+
+## Supported Workflow Starters
+
+This repo uses three supported workflow entry points:
+
+- repo-local skills under `.agents/skills/`
+- repo-scoped slash commands under `.codex/prompts/`
+- deterministic `make` targets and shell scripts
+
+Use them together, not as competing systems.
+
+## Skills
+
+Use repo-local skills when you want Codex to enter a repo-specific workflow directly.
+
+- `$content-brainstormer`
+- `$technical-post-drafter`
+- `$fact-checker`
+- `$jekyll-post-publisher`
+- `$medium-porter`
+- `$repo-flow`
+- `$official-doc-verifier`
+- `$site-quality-auditor`
+
+In the Codex app, enabled skills also appear in the slash-command picker through
+`agents/openai.yaml`.
+
+## Repo Slash Commands
+
+Official Codex docs support custom slash commands. This repo keeps committed workflow starters
+under `.codex/prompts/`.
+
+- `/editorial-workflow`
+- `/site-quality`
+- `/repo-workflow`
+- `/official-docs`
+
+Use these when you want a short entry point that expands into the repo's preferred skill and QA
+flow.
+
+## Make Commands
+
+Use `make` for deterministic repo actions and validation.
+
+- `make start-work TOPIC="..." TYPE=feat`
+- `make validate-draft PATH=_drafts/post.md`
+- `make qa-publish PATH=_drafts/post.md`
+- `make publish-draft PATH=_drafts/post.md DATE=YYYY-MM-DD`
+- `make site-audit AUDIT=seo TARGET=site`
+- `make codex-check`
+- `make check`
+- `make qa-local`
+- `make create-pr TYPE=feat`
+- `make finalize-merge PR=123`
+
+## Release Gate
+
+Follow this order for repo-changing work:
+
+1. Start from `main` with `make start-work`.
+2. Implement the change.
+3. Run `make qa-local`.
+4. Preview locally with `bundle exec jekyll serve` if site-facing files changed.
+5. Group clean Conventional Commits only after the full QA gate passes.
+6. Re-run `make qa-local` on the committed tree.
+7. Create the PR with `make create-pr`.
+8. Integrate with `make finalize-merge`.
+
+## Scope Rules
+
+- This repo follows trunk-based development with rebase-only integration.
+- Do not rely on multi-agent features for this repo.
+- Prefer repo-local truth first, then Context7, then first-party docs.

--- a/.codex/docs/codex-usage.md
+++ b/.codex/docs/codex-usage.md
@@ -1,43 +1,74 @@
 # Codex Usage
 
-## Supported Workflow Starters
+## What Codex Officially Documents
 
-This repo uses three supported workflow entry points:
+For the Codex app and IDE extension, the official surfaces relevant to this repo are:
+
+- built-in Codex slash commands for Codex controls, such as `/local`, `/cloud`, `/review`, and
+  `/status`
+- explicit skill invocation with `$skill-name`
+- skills appearing in the app or IDE picker through `agents/openai.yaml`
+- `@file` references in the IDE extension for repo files and open files
+
+This repo does not treat `.codex/prompts/*` as Codex-native custom commands.
+
+## What This Repo Adds
+
+This repo adds three reusable layers on top of the official Codex surfaces:
 
 - repo-local skills under `.agents/skills/`
-- repo-scoped slash commands under `.codex/prompts/`
+- repo workflow prompt files under `.codex/prompts/`
 - deterministic `make` targets and shell scripts
 
-Use them together, not as competing systems.
+Use them together, not as competing systems:
 
-## Skills
+- prompt file or prompt text starts the workflow
+- skills drive repo-specific reasoning
+- `make` commands do the deterministic work
 
-Use repo-local skills when you want Codex to enter a repo-specific workflow directly.
+## VS Code / Cursor Usage
 
-- `$content-brainstormer`
-- `$technical-post-drafter`
-- `$fact-checker`
-- `$jekyll-post-publisher`
-- `$medium-porter`
-- `$repo-flow`
-- `$official-doc-verifier`
-- `$site-quality-auditor`
+In the Codex IDE extension for VS Code or Cursor, start workflow runs by referencing a repo prompt
+file directly:
 
-In the Codex app, enabled skills also appear in the slash-command picker through
-`agents/openai.yaml`.
+- `@.codex/prompts/site-workflow.md`
+- `@.codex/prompts/editorial-workflow.md`
+- `@.codex/prompts/medium-to-blog.md`
 
-## Repo Slash Commands
+These are IDE file references to reusable prompt files in the repo. They are not built-in Codex
+slash commands.
 
-Official Codex docs support custom slash commands. This repo keeps committed workflow starters
-under `.codex/prompts/`.
+Built-in slash commands remain useful for Codex controls only, for example:
 
-- `/editorial-workflow`
-- `/site-quality`
-- `/repo-workflow`
-- `/official-docs`
+- `/local`
+- `/cloud`
+- `/review`
+- `/status`
 
-Use these when you want a short entry point that expands into the repo's preferred skill and QA
-flow.
+## Codex App Usage
+
+In the Codex app, use explicit multi-skill prompts as the primary workflow starter.
+
+Site work:
+
+```text
+$site-quality-auditor $official-doc-verifier $repo-flow
+```
+
+Draft + publish:
+
+```text
+$content-brainstormer $technical-post-drafter $fact-checker $jekyll-post-publisher $repo-flow
+```
+
+Medium migration:
+
+```text
+$medium-porter $fact-checker $jekyll-post-publisher $repo-flow
+```
+
+If you want the repo prompt-file behavior in the app, paste the prompt file content into the
+thread instead of assuming `@.codex/prompts/...` is supported there.
 
 ## Make Commands
 
@@ -54,18 +85,65 @@ Use `make` for deterministic repo actions and validation.
 - `make create-pr TYPE=feat`
 - `make finalize-merge PR=123`
 
-## Release Gate
+## How Start-To-Finish Works
 
-Follow this order for repo-changing work:
+1. Start the workflow:
+   use `@.codex/prompts/<workflow>.md` in VS Code or Cursor, or use the equivalent `$skills`
+   prompt in the Codex app.
+2. Let Codex select and sequence the repo-local skills needed for the task.
+3. Let Codex use the repo `make` targets for deterministic validation, publication, and PR
+   packaging.
+4. Finish only when QA has passed, clean commits exist, the branch is pushed, and the PR is open.
 
-1. Start from `main` with `make start-work`.
-2. Implement the change.
-3. Run `make qa-local`.
-4. Preview locally with `bundle exec jekyll serve` if site-facing files changed.
-5. Group clean Conventional Commits only after the full QA gate passes.
-6. Re-run `make qa-local` on the committed tree.
-7. Create the PR with `make create-pr`.
-8. Integrate with `make finalize-merge`.
+## Copy-Paste Examples
+
+### Site Work
+
+VS Code / Cursor:
+
+```text
+@.codex/prompts/site-workflow.md Review the about page and tag archive for SEO, metadata, and maintenance issues, make the fixes, run the relevant audits, run make qa-local, and open the PR.
+```
+
+Codex app:
+
+```text
+$site-quality-auditor $official-doc-verifier $repo-flow
+
+Review the about page and tag archive for SEO, metadata, and maintenance issues, make the fixes, run the relevant audits, run make qa-local, group clean commits, and open the PR.
+```
+
+### Draft + Publish A Blog Post
+
+VS Code / Cursor:
+
+```text
+@.codex/prompts/editorial-workflow.md Turn this outline into a private draft in _drafts, fact-check the technical claims, publish it into _posts with the correct date, run QA, and open the PR: ...
+```
+
+Codex app:
+
+```text
+$content-brainstormer $technical-post-drafter $fact-checker $jekyll-post-publisher $repo-flow
+
+Turn this outline into a private draft in _drafts, fact-check the technical claims, publish it into _posts with the correct date, run QA, group clean commits, and open the PR: ...
+```
+
+### Medium Link To Blog Post
+
+VS Code / Cursor:
+
+```text
+@.codex/prompts/medium-to-blog.md Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, and open the PR: https://medium.com/example-post
+```
+
+Codex app:
+
+```text
+$medium-porter $fact-checker $jekyll-post-publisher $repo-flow
+
+Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, group clean commits, and open the PR: https://medium.com/example-post
+```
 
 ## Scope Rules
 

--- a/.codex/docs/prompt-recipes.md
+++ b/.codex/docs/prompt-recipes.md
@@ -20,6 +20,20 @@
 
 `Use $repo-flow to package these tracked changes into a clean PR for this repository.`
 
+## Site Quality
+
+`Use $site-quality-auditor to review this change for site SEO, shared head metadata, archive-page quality, and maintenance risks.`
+
 ## Official Docs
 
 `Use $official-doc-verifier to confirm the official docs for this tool before we encode the workflow behavior.`
+
+## Repo Slash Commands
+
+`/editorial-workflow`
+
+`/site-quality`
+
+`/repo-workflow`
+
+`/official-docs`

--- a/.codex/docs/prompt-recipes.md
+++ b/.codex/docs/prompt-recipes.md
@@ -1,39 +1,51 @@
 # Prompt Recipes
 
-## Brainstorm
+## Site Work In VS Code / Cursor
+
+```text
+@.codex/prompts/site-workflow.md Review the about page and tag archive for SEO, metadata, and maintenance issues, make the fixes, run the relevant audits, run make qa-local, and open the PR.
+```
+
+## Site Work In The Codex App
+
+```text
+$site-quality-auditor $official-doc-verifier $repo-flow
+
+Review the about page and tag archive for SEO, metadata, and maintenance issues, make the fixes, run the relevant audits, run make qa-local, group clean commits, and open the PR.
+```
+
+## Draft + Publish In VS Code / Cursor
+
+```text
+@.codex/prompts/editorial-workflow.md Turn this outline into a private draft in _drafts, fact-check the technical claims, publish it into _posts with the correct date, run QA, and open the PR: ...
+```
+
+## Draft + Publish In The Codex App
+
+```text
+$content-brainstormer $technical-post-drafter $fact-checker $jekyll-post-publisher $repo-flow
+
+Turn this outline into a private draft in _drafts, fact-check the technical claims, publish it into _posts with the correct date, run QA, group clean commits, and open the PR: ...
+```
+
+## Medium To Blog In VS Code / Cursor
+
+```text
+@.codex/prompts/medium-to-blog.md Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, and open the PR: https://medium.com/example-post
+```
+
+## Medium To Blog In The Codex App
+
+```text
+$medium-porter $fact-checker $jekyll-post-publisher $repo-flow
+
+Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, group clean commits, and open the PR: https://medium.com/example-post
+```
+
+## Focused Skills
 
 `Use $content-brainstormer to propose three authority-first post ideas about debugging brittle mobile systems.`
 
-## Draft
-
-`Use $jekyll-post-publisher to create a private draft from this outline and this Unsplash URL: ...`
-
-## Fact Check
-
 `Use $fact-checker to verify these claims and tell me what needs stronger sourcing.`
 
-## Medium Migration
-
-`Use $medium-porter to migrate this Medium article into a site-native draft while preserving the voice.`
-
-## Repo Workflow
-
-`Use $repo-flow to package these tracked changes into a clean PR for this repository.`
-
-## Site Quality
-
-`Use $site-quality-auditor to review this change for site SEO, shared head metadata, archive-page quality, and maintenance risks.`
-
-## Official Docs
-
 `Use $official-doc-verifier to confirm the official docs for this tool before we encode the workflow behavior.`
-
-## Repo Slash Commands
-
-`/editorial-workflow`
-
-`/site-quality`
-
-`/repo-workflow`
-
-`/official-docs`

--- a/.codex/docs/site-quality.md
+++ b/.codex/docs/site-quality.md
@@ -11,25 +11,32 @@ Use it for:
 - site-quality review
 - maintainability review
 
-## Entry Points
+## How To Start This Workflow
 
-Skill:
+VS Code / Cursor:
 
 ```text
-$site-quality-auditor
+@.codex/prompts/site-workflow.md
 ```
 
-Command:
+Codex app:
+
+```text
+$site-quality-auditor $official-doc-verifier $repo-flow
+```
+
+Deterministic audit command:
 
 ```bash
 make site-audit AUDIT=seo TARGET=site
 ```
 
-Slash command:
+## Workflow Shapes
 
-```text
-/site-quality
-```
+- `.codex/prompts/site-workflow.md`: full site-change workflow from request to QA, grouped
+  commits, and PR
+- `.codex/prompts/site-quality.md`: focused site QA or a narrower site change prompt
+- `make site-audit`: deterministic source-level audit command
 
 ## Audit Modes
 

--- a/.codex/docs/site-quality.md
+++ b/.codex/docs/site-quality.md
@@ -1,0 +1,50 @@
+# Site Quality
+
+## Purpose
+
+This workflow covers source-level website maintenance and QA for the Jekyll site.
+
+Use it for:
+
+- SEO review
+- performance review
+- site-quality review
+- maintainability review
+
+## Entry Points
+
+Skill:
+
+```text
+$site-quality-auditor
+```
+
+Command:
+
+```bash
+make site-audit AUDIT=seo TARGET=site
+```
+
+Slash command:
+
+```text
+/site-quality
+```
+
+## Audit Modes
+
+- `seo`: checks plugins, metadata surfaces, JSON-LD, indexing overrides, and page metadata
+- `performance`: checks obvious source-level performance risks such as global scripts and large local assets
+- `quality`: checks page metadata, layout and front matter consistency, archive and 404 expectations, and workflow alignment
+- `maintenance`: checks remote dependencies, third-party scripts, and workflow drift
+
+## What This Workflow Does Not Do
+
+- It does not pretend a live browser audit happened.
+- It does not replace editorial skills.
+- It does not replace manual preview when site-facing files changed.
+
+## Required Follow-Up
+
+If a change touches `_config.yml`, `_includes/`, `_layouts/`, `_pages/`, `_posts/`, `assets/`,
+or `_sass/`, preview locally with `bundle exec jekyll serve` before commit.

--- a/.codex/docs/tooling.md
+++ b/.codex/docs/tooling.md
@@ -3,6 +3,7 @@
 ## Philosophy
 
 Local checks are the primary quality gate. CI is intentionally light and acts as a backup signal.
+Do not commit until the full local QA gate passes.
 
 ## One-Shot Setup
 
@@ -33,7 +34,7 @@ make hooks-install
 Hook stages:
 
 - `pre-commit`: fast checks only
-- `pre-push`: heavier tracked-content and security checks
+- `pre-push`: the full release-grade local QA gate
 
 `make setup` installs both hook stages automatically.
 
@@ -60,6 +61,37 @@ This runs targeted Semgrep checks against shell scripts and workflow YAML.
 Targets are discovered dynamically from `scripts/`, `.codex/`, and `.github/workflows/`,
 plus the repo's `.semgrep.yml`.
 
+## Codex Workflow Checks
+
+Run:
+
+```bash
+make codex-check
+```
+
+This validates repo-local skills, repo-scoped slash commands under `.codex/prompts/`,
+and required Codex workflow docs.
+
+## Site Audit
+
+Run:
+
+```bash
+make site-audit AUDIT=seo TARGET=site
+```
+
+Use this for source-level SEO, quality, performance, and maintenance audits.
+
+## Full Local QA
+
+Run:
+
+```bash
+make qa-local
+```
+
+This is the required local release gate before commit, push, PR creation, or rebase integration.
+
 ## Tracked Repo QA
 
 Run:
@@ -69,3 +101,5 @@ make check
 ```
 
 This validates changed tracked posts and runs the Jekyll build.
+Because the repo uses `remote_theme`, a clean environment may still need network access or a
+cached theme for `make check` to succeed.

--- a/.codex/docs/tooling.md
+++ b/.codex/docs/tooling.md
@@ -69,8 +69,8 @@ Run:
 make codex-check
 ```
 
-This validates repo-local skills, repo-scoped slash commands under `.codex/prompts/`,
-and required Codex workflow docs.
+This validates repo-local skills, repo workflow prompt files under `.codex/prompts/`, and
+required Codex workflow docs.
 
 ## Site Audit
 

--- a/.codex/docs/workflows.md
+++ b/.codex/docs/workflows.md
@@ -1,91 +1,119 @@
 # Workflows
 
-## Brainstorm A Post
+## Site Work
 
-Use `$content-brainstormer` to generate authority-first ideas, hooks, and outlines.
-
-Slash command:
+### Site Starter In VS Code / Cursor
 
 ```text
-/editorial-workflow
+@.codex/prompts/site-workflow.md Review the about page and tag archive for SEO, metadata, and maintenance issues, make the fixes, run the relevant audits, run make qa-local, and open the PR.
 ```
 
-## Create A Private Draft
+### Site Starter In The Codex App
 
-Create the draft locally under `_drafts/` and include:
+```text
+$site-quality-auditor $official-doc-verifier $repo-flow
 
-- title
-- description
-- categories
-- tags
-- Unsplash image URL
-- `image_alt`
-- `fact_check_status`
-
-## Validate A Draft
-
-Run:
-
-```bash
-make validate-draft PATH=_drafts/your-post.md
+Review the about page and tag archive for SEO, metadata, and maintenance issues, make the fixes, run the relevant audits, run make qa-local, group clean commits, and open the PR.
 ```
 
-This checks metadata, placeholders, image rules, and markdown lint for the private draft.
+### Site Phases
 
-## Publish QA
+1. Start the branch with `make start-work TOPIC="..." TYPE=...`.
+2. Inspect the affected site files.
+3. Run the relevant audits with `make site-audit`.
+4. Make the site changes.
+5. Preview locally with `bundle exec jekyll serve` if site-facing files changed.
+6. Run `make qa-local`.
+7. Group clean commits, re-run `make qa-local`, and run `make create-pr TYPE=...`.
 
-Run:
+### Site Commands
 
-```bash
-make qa-publish PATH=_drafts/your-post.md
+- `make start-work TOPIC="..." TYPE=...`
+- `make site-audit AUDIT=seo TARGET=...`
+- `make site-audit AUDIT=quality TARGET=...`
+- `make site-audit AUDIT=maintenance TARGET=...`
+- `make site-audit AUDIT=performance TARGET=...`
+- `make qa-local`
+- `make create-pr TYPE=...`
+
+### Site Finish
+
+The workflow finishes when the PR is open and ready for self-review.
+
+## Draft + Publish A Blog Post
+
+### Draft Starter In VS Code / Cursor
+
+```text
+@.codex/prompts/editorial-workflow.md Turn this outline into a private draft in _drafts, fact-check the technical claims, publish it into _posts with the correct date, run QA, and open the PR: ...
 ```
 
-This is the final pre-publish gate.
+### Draft Starter In The Codex App
 
-## Publish A Draft
+```text
+$content-brainstormer $technical-post-drafter $fact-checker $jekyll-post-publisher $repo-flow
 
-Run:
-
-```bash
-make publish-draft PATH=_drafts/your-post.md DATE=YYYY-MM-DD
+Turn this outline into a private draft in _drafts, fact-check the technical claims, publish it into _posts with the correct date, run QA, group clean commits, and open the PR: ...
 ```
 
-This creates the tracked `_posts/YYYY-MM-DD-slug.md` file.
+### Draft Phases
 
-## Fact-Check A Draft
+1. Start the branch with `make start-work TOPIC="..." TYPE=feat`.
+2. Brainstorm the angle if needed, then draft the article body.
+3. Fact-check technical and time-sensitive claims.
+4. Create or refine the private draft under `_drafts/`.
+5. Run draft validation and publish QA.
+6. Promote the draft into `_posts/`.
+7. Run `make qa-local`, group clean commits, and open the PR.
 
-Use `$fact-checker` before publish when the draft contains technical or time-sensitive claims.
+### Draft Commands
 
-## Migrate A Medium Post
+- `make start-work TOPIC="..." TYPE=feat`
+- `make validate-draft PATH=_drafts/<draft>.md`
+- `make qa-publish PATH=_drafts/<draft>.md`
+- `make publish-draft PATH=_drafts/<draft>.md DATE=YYYY-MM-DD`
+- `make qa-local`
+- `make create-pr TYPE=feat`
 
-Use `$medium-porter`, then run the same local draft validation and publish flow.
+### Draft Finish
 
-## Audit Site Quality
+The workflow finishes when the post exists in `_posts/` and the PR is open.
 
-Use `$site-quality-auditor` or run:
+## Port A Medium Post
 
-```bash
-make site-audit AUDIT=seo TARGET=site
+### Medium Starter In VS Code / Cursor
+
+```text
+@.codex/prompts/medium-to-blog.md Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, and open the PR: https://medium.com/example-post
 ```
 
-Use this workflow for source-level SEO, quality, performance, and maintenance review.
+### Medium Starter In The Codex App
 
-## Verify Official Docs
+```text
+$medium-porter $fact-checker $jekyll-post-publisher $repo-flow
 
-Use `$official-doc-verifier` when a workflow or implementation depends on current official docs.
-
-## Create And Integrate A PR
-
-Run:
-
-```bash
-make qa-local
-make create-pr TYPE=feat
-make finalize-merge PR=<number>
+Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, group clean commits, and open the PR: https://medium.com/example-post
 ```
 
-Do not commit until `make qa-local` passes. If site-facing files changed, preview with
-`bundle exec jekyll serve` before commit.
+### Medium Phases
 
-The repo uses trunk-based development with rebase-only integration. No merge commits are part of
-the workflow.
+1. Start the branch with `make start-work TOPIC="..." TYPE=feat`.
+2. Convert the Medium article into a private draft under `_drafts/`.
+3. Normalize metadata, taxonomy, and structure for this site.
+4. Fact-check anything time-sensitive or technical.
+5. Run draft validation and publish QA.
+6. Promote the draft into `_posts/`.
+7. Run `make qa-local`, group clean commits, and open the PR.
+
+### Medium Commands
+
+- `make start-work TOPIC="..." TYPE=feat`
+- `make validate-draft PATH=_drafts/<draft>.md`
+- `make qa-publish PATH=_drafts/<draft>.md`
+- `make publish-draft PATH=_drafts/<draft>.md DATE=YYYY-MM-DD`
+- `make qa-local`
+- `make create-pr TYPE=feat`
+
+### Medium Finish
+
+The workflow finishes when the migrated post exists in `_posts/` and the PR is open.

--- a/.codex/docs/workflows.md
+++ b/.codex/docs/workflows.md
@@ -4,6 +4,12 @@
 
 Use `$content-brainstormer` to generate authority-first ideas, hooks, and outlines.
 
+Slash command:
+
+```text
+/editorial-workflow
+```
+
 ## Create A Private Draft
 
 Create the draft locally under `_drafts/` and include:
@@ -54,14 +60,32 @@ Use `$fact-checker` before publish when the draft contains technical or time-sen
 
 Use `$medium-porter`, then run the same local draft validation and publish flow.
 
-## Create And Merge A PR
+## Audit Site Quality
+
+Use `$site-quality-auditor` or run:
+
+```bash
+make site-audit AUDIT=seo TARGET=site
+```
+
+Use this workflow for source-level SEO, quality, performance, and maintenance review.
+
+## Verify Official Docs
+
+Use `$official-doc-verifier` when a workflow or implementation depends on current official docs.
+
+## Create And Integrate A PR
 
 Run:
 
 ```bash
-make check
+make qa-local
 make create-pr TYPE=feat
 make finalize-merge PR=<number>
 ```
 
-The merge flow is solo self-review based. No external reviewer is required.
+Do not commit until `make qa-local` passes. If site-facing files changed, preview with
+`bundle exec jekyll serve` before commit.
+
+The repo uses trunk-based development with rebase-only integration. No merge commits are part of
+the workflow.

--- a/.codex/prompts/editorial-workflow.md
+++ b/.codex/prompts/editorial-workflow.md
@@ -1,11 +1,23 @@
 # Editorial Workflow
 
-Use this repository's editorial workflow.
+Use this repository's full net-new post workflow from topic or outline to published post and PR.
 
-- Route idea selection and outlines to `$content-brainstormer`.
-- Route article drafting or restructuring to `$technical-post-drafter`.
-- Route source verification to `$fact-checker`.
-- Route metadata, validation, and publication work to `$jekyll-post-publisher`.
-- Keep `_drafts/` private and local-only.
-- If repo files are being changed, follow `$repo-flow` and require `make qa-local` before commit.
-- Return the next concrete workflow step and the correct repo-local skill to use.
+- Use `$content-brainstormer` when the angle, hook, or outline is still fuzzy.
+- Use `$technical-post-drafter` to turn notes or outlines into a strong draft body.
+- Use `$fact-checker` for technical or time-sensitive claims before calling the post publish-ready.
+- Use `$jekyll-post-publisher` for draft creation, front matter, validation, publish QA, and
+  promotion into `_posts/`.
+- Use `$repo-flow` once tracked files exist and the work needs branch, commit, and PR packaging.
+- Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=feat`.
+- Create or refine the private draft under `_drafts/`.
+- Ensure the draft has publish-ready metadata before publication.
+- Run:
+  `make validate-draft PATH=_drafts/<draft>.md`
+  `make qa-publish PATH=_drafts/<draft>.md`
+  `make publish-draft PATH=_drafts/<draft>.md DATE=YYYY-MM-DD`
+- After `_posts/` is updated, run `make qa-local`.
+- Group clean Conventional Commits only after QA passes.
+- Re-run `make qa-local` on the committed tree.
+- Run `make create-pr TYPE=feat`.
+- If the work is actually a Medium migration, use `.codex/prompts/medium-to-blog.md` instead.
+- Finish only when the tracked post exists in `_posts/` and the PR is open.

--- a/.codex/prompts/editorial-workflow.md
+++ b/.codex/prompts/editorial-workflow.md
@@ -1,0 +1,11 @@
+# Editorial Workflow
+
+Use this repository's editorial workflow.
+
+- Route idea selection and outlines to `$content-brainstormer`.
+- Route article drafting or restructuring to `$technical-post-drafter`.
+- Route source verification to `$fact-checker`.
+- Route metadata, validation, and publication work to `$jekyll-post-publisher`.
+- Keep `_drafts/` private and local-only.
+- If repo files are being changed, follow `$repo-flow` and require `make qa-local` before commit.
+- Return the next concrete workflow step and the correct repo-local skill to use.

--- a/.codex/prompts/medium-to-blog.md
+++ b/.codex/prompts/medium-to-blog.md
@@ -1,0 +1,22 @@
+# Medium To Blog
+
+Use this repository's full Medium migration workflow from source URL to published post and PR.
+
+- Use `$medium-porter` to convert the Medium article into a site-native draft while preserving
+  voice and thesis.
+- Use `$fact-checker` for technical or time-sensitive claims before publication.
+- Use `$jekyll-post-publisher` for front matter, validation, publish QA, and promotion into
+  `_posts/`.
+- Use `$repo-flow` for branch creation, QA, commit grouping, and PR packaging.
+- Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=feat`.
+- Ingest the Medium URL and convert it into a private draft under `_drafts/`.
+- Adapt metadata, taxonomy, structure, and formatting to this repo.
+- Run:
+  `make validate-draft PATH=_drafts/<draft>.md`
+  `make qa-publish PATH=_drafts/<draft>.md`
+  `make publish-draft PATH=_drafts/<draft>.md DATE=YYYY-MM-DD`
+- After `_posts/` is updated, run `make qa-local`.
+- Group clean Conventional Commits only after QA passes.
+- Re-run `make qa-local` on the committed tree.
+- Run `make create-pr TYPE=feat`.
+- Finish only when the tracked post exists in `_posts/` and the PR is open.

--- a/.codex/prompts/official-docs.md
+++ b/.codex/prompts/official-docs.md
@@ -1,0 +1,9 @@
+# Official Docs Workflow
+
+Use the repository's official documentation verification workflow.
+
+- Start with `$official-doc-verifier`.
+- Check repo-local truth first.
+- Use Context7 when the official docs are available there.
+- Fall back to first-party docs only when Context7 is not the right source.
+- Summarize the confirmed behavior and its implementation impact before editing code or docs.

--- a/.codex/prompts/repo-workflow.md
+++ b/.codex/prompts/repo-workflow.md
@@ -1,0 +1,10 @@
+# Repo Workflow
+
+Use this repository's standard repo flow.
+
+- Follow `$repo-flow`.
+- Start repo-changing work from `main` on a fresh `codex/*` branch using `make start-work`.
+- Do not commit until `make qa-local` passes.
+- Group related changes into clean Conventional Commits after the full local QA gate is green.
+- Re-run `make qa-local` on the committed tree before push and PR creation.
+- Use `make create-pr` and `make finalize-merge` instead of ad hoc PR and integration commands.

--- a/.codex/prompts/site-quality.md
+++ b/.codex/prompts/site-quality.md
@@ -1,10 +1,13 @@
 # Site Quality Workflow
 
-Use this repository's site QA workflow.
+Use this prompt for focused site QA or a narrow site change, not for the full request-to-PR flow.
 
 - Start with `$site-quality-auditor`.
 - Audit for one of: SEO, performance, quality, or maintenance.
 - Ground the review in `_config.yml`, shared head includes, JSON-LD, and the affected pages.
 - Use `make site-audit AUDIT=<mode> TARGET=<target>` when deterministic repo-local checks help.
 - If the workflow or version-sensitive behavior is unclear, use `$official-doc-verifier`.
+- If the user wants the full site workflow through grouped commits and PR creation, use
+  `.codex/prompts/site-workflow.md` in IDE contexts or the equivalent multi-skill prompt in the
+  Codex app.
 - If repo files are changed, require `make qa-local` before commit.

--- a/.codex/prompts/site-quality.md
+++ b/.codex/prompts/site-quality.md
@@ -1,0 +1,10 @@
+# Site Quality Workflow
+
+Use this repository's site QA workflow.
+
+- Start with `$site-quality-auditor`.
+- Audit for one of: SEO, performance, quality, or maintenance.
+- Ground the review in `_config.yml`, shared head includes, JSON-LD, and the affected pages.
+- Use `make site-audit AUDIT=<mode> TARGET=<target>` when deterministic repo-local checks help.
+- If the workflow or version-sensitive behavior is unclear, use `$official-doc-verifier`.
+- If repo files are changed, require `make qa-local` before commit.

--- a/.codex/prompts/site-workflow.md
+++ b/.codex/prompts/site-workflow.md
@@ -1,0 +1,23 @@
+# Site Workflow
+
+Use this repository's full site-change workflow from request to PR.
+
+- Use `$site-quality-auditor` for repo-specific site review and fixes.
+- Use `$official-doc-verifier` when Jekyll, Minimal Mistakes, Codex, or another tool has
+  version-sensitive behavior.
+- Use `$repo-flow` for branch creation, QA, commit grouping, and PR packaging.
+- Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=...`.
+- Inspect the affected files before editing.
+- Choose the relevant audit modes and run the matching commands:
+  `make site-audit AUDIT=seo TARGET=...`
+  `make site-audit AUDIT=quality TARGET=...`
+  `make site-audit AUDIT=maintenance TARGET=...`
+  `make site-audit AUDIT=performance TARGET=...` when performance review is relevant.
+- Make the required repo changes.
+- If site-facing files changed, require a local preview with `bundle exec jekyll serve` before
+  commit.
+- Run `make qa-local`.
+- Group clean Conventional Commits only after QA passes.
+- Re-run `make qa-local` on the committed tree.
+- Run `make create-pr TYPE=...`.
+- Finish only when the PR is open and ready for self-review.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,15 +46,9 @@ repos:
         pass_filenames: true
         require_serial: true
         stages: [pre-commit]
-      - id: run-checks
-        name: run make check
-        entry: ./scripts/run-checks.sh
-        language: system
-        pass_filenames: false
-        stages: [pre-push]
-      - id: run-security-checks
-        name: run targeted semgrep checks
-        entry: ./scripts/run-security-checks.sh
+      - id: run-local-qa
+        name: run release-grade local QA
+        entry: ./scripts/run-local-qa.sh
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -5,8 +5,9 @@ rules:
     languages: [bash]
     paths:
       include:
-        - "scripts/**/*.sh"
-        - ".agents/**/*.sh"
+        - "/scripts/*.sh"
+        - "/scripts/**/*.sh"
+        - "/.agents/**/*.sh"
     pattern: eval $X
 
   - id: no-curl-pipe-shell
@@ -15,8 +16,9 @@ rules:
     languages: [bash]
     paths:
       include:
-        - "scripts/**/*.sh"
-        - ".agents/**/*.sh"
+        - "/scripts/*.sh"
+        - "/scripts/**/*.sh"
+        - "/.agents/**/*.sh"
     pattern-regex: 'curl\\b[^\\n|]*\\|\\s*(sh|bash)\\b'
 
   - id: no-wget-pipe-shell
@@ -25,8 +27,9 @@ rules:
     languages: [bash]
     paths:
       include:
-        - "scripts/**/*.sh"
-        - ".agents/**/*.sh"
+        - "/scripts/*.sh"
+        - "/scripts/**/*.sh"
+        - "/.agents/**/*.sh"
     pattern-regex: 'wget\\b[^\\n|]*\\|\\s*(sh|bash)\\b'
 
   - id: disallow-pull-request-target-workflows
@@ -35,6 +38,6 @@ rules:
     languages: [generic]
     paths:
       include:
-        - ".github/workflows/**/*.yml"
-        - ".github/workflows/**/*.yaml"
+        - "/.github/workflows/*.yml"
+        - "/.github/workflows/*.yaml"
     pattern-regex: 'pull_request_target:'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - `_posts/` stores published dated blog content in Markdown. Follow the `YYYY-MM-DD-title.md` naming pattern.
 - `_drafts/` is a private local-only workspace for unpublished drafts. It is gitignored on purpose and should not be committed.
 - `.agents/skills/` stores repo-local Codex skills in the official Codex location. Treat these as the source of truth for this repository's AI workflow.
+- `.codex/prompts/` stores repo-scoped custom Codex slash commands for recurring workflow starters.
 - `.codex/docs/` stores repo-owned workflow, tooling, and editorial policy docs.
 - `_includes/` and `_layouts/` (theme overrides) support shared partials. Favor `_includes` for reusable snippets and keep Liquid logic minimal.
 - `_sass/` contains custom SCSS partials layered atop the Minimal Mistakes theme. Import new partials via `assets/css/main.scss`.
@@ -20,9 +21,12 @@
 - `make validate-draft PATH=_drafts/post.md` validates a private local draft.
 - `make qa-publish PATH=_drafts/post.md` runs the full publish-readiness gate.
 - `make publish-draft PATH=_drafts/post.md DATE=YYYY-MM-DD` promotes a private draft into `_posts/`.
+- `make site-audit AUDIT=seo TARGET=site` runs repo-local site QA for SEO, quality, performance, or maintenance review.
+- `make codex-check` validates repo-local skills, prompts, and Codex workflow docs.
+- `make qa-local` runs the full release-grade local QA gate before commit, push, PR, or rebase integration.
 - `make check` validates tracked post changes and runs the Jekyll build gate.
 - `make create-pr TYPE=...` prepares a consistent PR title and description after local checks pass.
-- `make finalize-merge PR=...` completes the solo self-review merge flow.
+- `make finalize-merge PR=...` completes the solo self-review rebase-integration flow.
 
 ## Coding Style & Naming Conventions
 
@@ -34,23 +38,27 @@
 
 ## Testing Guidelines
 
-- Rely on Jekyll's build step as the baseline tracked-content regression check.
+- Treat `make qa-local` as the full local release gate.
+- Rely on Jekyll's build step as the baseline tracked-content regression check inside `make check`.
 - Use `make validate-draft` for gitignored drafts and `make qa-publish` before any draft is promoted to `_posts/`.
-- Use `make check` before PR creation and before merge.
-- When modifying navigation, front matter, or permalinks, spot-check rendered pages at `http://localhost:4000`.
+- Run `make site-audit` when reviewing site metadata, archive pages, shared head includes, or website maintainability changes.
+- If a change touches `_config.yml`, `_includes/`, `_layouts/`, `_pages/`, `_posts/`, `assets/`, or `_sass/`, preview locally with `bundle exec jekyll serve` before commit.
 
 ## Commit & Pull Request Guidelines
 
 - Follow Conventional Commits (`feat:`, `fix:`, `style:`) as seen in recent history (`git log --oneline`). Keep messages in imperative mood.
 - Group related changes per commit; avoid mixing content updates with workflow/tooling work.
+- Do not commit until `make qa-local` passes.
+- Re-run `make qa-local` on the committed tree before push and PR creation.
 - Pull requests exist for packaging, review context, and clean history even though this is a solo-maintainer repo.
 - Ensure local checks pass before opening a PR. CI is backup only, not the primary development loop.
-- Branching model is trunk-based: create short-lived branches off `main`, rebase if they drift, and merge back with a linear history.
+- Branching model is trunk-based development: create short-lived branches off `main`, rebase if they drift, and integrate back with rebase only.
 
 ## Repo-Local Skills Policy
 
 - Repo-local skills live in `.agents/skills/` and take precedence over user-global skills when both apply.
 - Use repo-local skills first for private draft creation, technical draft development, post editing, brainstorming, fact checking, Medium migration, repo workflow automation, and official documentation verification.
+- Prefer adapting external skills into repo-native workflows before vendoring them into `.agents/skills/`.
 - Keep `SKILL.md` files concise. Put detailed policy in `references/` and deterministic logic in `scripts/`.
 
 ## Context7 And Official Docs Policy
@@ -75,11 +83,11 @@
 - Cover images are usually remote Unsplash URLs supplied in the prompt. Local image assets are the exception.
 - Topic development should bias toward authority-building topics in mobile architecture, debugging, systems thinking, AI engineering, and principal mobile engineering leadership.
 
-## Solo Merge Policy
+## Solo Integration Policy
 
 - External reviewer approval is not required.
-- Merges require local checks, a PR, and an explicit self-review confirmation step.
-- If CI has reported failures, fix them before merging.
+- Rebase-only integration requires local checks, a PR, and an explicit self-review confirmation step.
+- If CI has reported failures, fix them before integration.
 
 ## Bash Security Policy
 
@@ -96,5 +104,6 @@
 - `technical-post-drafter`: Turn outlines, notes, and rough drafts into strong technical article bodies before fact checking and publish QA.
 - `fact-checker`: Verify technical and time-sensitive claims with primary sources and official documentation.
 - `medium-porter`: Convert and polish Medium posts into site-native Jekyll content.
-- `repo-flow`: Standardize branch creation, local checks, PR authoring, and solo self-review merge completion.
+- `repo-flow`: Standardize branch creation, local checks, PR authoring, and solo self-review rebase integration completion.
 - `official-doc-verifier`: Decide when official docs are required and push the workflow toward Context7 or first-party sources.
+- `site-quality-auditor`: Audit the site for source-level SEO, performance, quality, and maintainability issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - `_posts/` stores published dated blog content in Markdown. Follow the `YYYY-MM-DD-title.md` naming pattern.
 - `_drafts/` is a private local-only workspace for unpublished drafts. It is gitignored on purpose and should not be committed.
 - `.agents/skills/` stores repo-local Codex skills in the official Codex location. Treat these as the source of truth for this repository's AI workflow.
-- `.codex/prompts/` stores repo-scoped custom Codex slash commands for recurring workflow starters.
+- `.codex/prompts/` stores repo workflow prompt files for recurring Codex App and IDE starters.
 - `.codex/docs/` stores repo-owned workflow, tooling, and editorial policy docs.
 - `_includes/` and `_layouts/` (theme overrides) support shared partials. Favor `_includes` for reusable snippets and keep Liquid logic minimal.
 - `_sass/` contains custom SCSS partials layered atop the Minimal Mistakes theme. Import new partials via `assets/css/main.scss`.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help setup hooks-install lint security validate-draft qa-publish publish-draft start-work check create-pr finalize-merge skill-audit skill-vendor
+.PHONY: help setup hooks-install lint security codex-check site-audit qa-local validate-draft qa-publish publish-draft start-work check create-pr finalize-merge skill-audit skill-vendor
 
 ifneq (,$(filter skill-audit skill-vendor,$(firstword $(MAKECMDGOALS))))
 SKILL_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -9,17 +9,32 @@ endif
 
 help:
 	@echo "Available targets:"
+	@echo ""
+	@echo "Setup:"
 	@echo "  make setup"
 	@echo "  make hooks-install"
-	@echo "  make lint"
-	@echo "  make security"
+	@echo ""
+	@echo "Editorial:"
 	@echo "  make validate-draft PATH=_drafts/post.md"
 	@echo "  make qa-publish PATH=_drafts/post.md"
 	@echo "  make publish-draft PATH=_drafts/post.md DATE=YYYY-MM-DD"
-	@echo "  make start-work TOPIC=\"...\" TYPE=chore"
+	@echo ""
+	@echo "Site Quality:"
+	@echo "  make site-audit AUDIT=seo TARGET=site"
+	@echo ""
+	@echo "QA:"
+	@echo "  make lint"
+	@echo "  make security"
+	@echo "  make codex-check"
 	@echo "  make check"
+	@echo "  make qa-local"
+	@echo ""
+	@echo "Repo Flow:"
+	@echo "  make start-work TOPIC=\"...\" TYPE=chore"
 	@echo "  make create-pr TYPE=feat"
 	@echo "  make finalize-merge PR=123"
+	@echo ""
+	@echo "Skill Governance:"
 	@echo "  make skill-audit NAME=example SOURCE=https://github.com/org/repo/tree/main/path"
 	@echo "  make skill-audit example"
 	@echo "  make skill-vendor SOURCE=https://github.com/org/repo/tree/main/path NAME=example"
@@ -36,6 +51,15 @@ lint:
 
 security:
 	@./scripts/run-security-checks.sh
+
+codex-check:
+	@./scripts/run-codex-checks.sh
+
+site-audit:
+	@/usr/bin/env AUDIT='$(AUDIT)' TARGET='$(TARGET)' /bin/bash -lc './scripts/site-audit.sh'
+
+qa-local:
+	@./scripts/run-local-qa.sh
 
 validate-draft:
 	@/usr/bin/env DRAFT_PATH='$(PATH)' /bin/bash -lc './scripts/validate-draft.sh "$$DRAFT_PATH"'

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This is my personal blog and writing archive. I occasionally share thoughts on p
 ## AI Workflow
 
 This repo includes a repo-local AI workflow for brainstorming, drafting, validating, publishing,
-auditing site quality, and packaging changes for review. Repo-scoped Codex slash commands live
-under `.codex/prompts/`. Start with
+auditing site quality, and packaging changes for review. Reusable repo workflow prompt files live
+under `.codex/prompts/`. In VS Code or Cursor, reference them with `@.codex/prompts/...`. Start
+with
 [`./.codex/docs/README.md`](./.codex/docs/README.md).
 
 ## Local Setup

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This is my personal blog and writing archive. I occasionally share thoughts on p
 ## AI Workflow
 
 This repo includes a repo-local AI workflow for brainstorming, drafting, validating, publishing,
-and packaging changes for review. Start with
+auditing site quality, and packaging changes for review. Repo-scoped Codex slash commands live
+under `.codex/prompts/`. Start with
 [`./.codex/docs/README.md`](./.codex/docs/README.md).
 
 ## Local Setup
@@ -38,6 +39,7 @@ That means normal `git commit` and `git push` already run the configured checks.
 Use these commands only when you want an explicit manual verification pass:
 
 ```bash
+make qa-local
 make check
 ./.venv-tools/bin/pre-commit run --all-files
 ./.venv-tools/bin/pre-commit run --hook-stage pre-push --all-files

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -24,7 +24,7 @@ if gh pr view "$branch" >/dev/null 2>&1; then
   exit 1
 fi
 
-"$repo_root/scripts/run-checks.sh"
+"$repo_root/scripts/run-local-qa.sh"
 
 remote_name="origin"
 if upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"; then
@@ -77,7 +77,7 @@ cat > "$body_file" <<EOF
 
 ## Validation
 
-- \`make check\`
+- \`make qa-local\`
 
 ## Affected Files
 
@@ -93,7 +93,7 @@ $affected_urls
 
 ## Self-review Notes
 
-- Local checks passed
+- Full local QA gate passed
 - Diff reviewed
 - No private drafts or secrets included
 EOF

--- a/scripts/finalize-merge.sh
+++ b/scripts/finalize-merge.sh
@@ -18,7 +18,7 @@ if [[ -z "$pr" ]]; then
   pr="$branch"
 fi
 
-"$repo_root/scripts/run-checks.sh"
+"$repo_root/scripts/run-local-qa.sh"
 
 pr_state="$(gh pr view "$pr" --json statusCheckRollup,isDraft,url)"
 is_draft="$(printf '%s' "$pr_state" | ruby -rjson -e 'data = JSON.parse(STDIN.read); print(data["isDraft"] ? "true" : "false")')"
@@ -66,16 +66,16 @@ fi
 
 cat <<EOF
 Self-review checklist for $pr_url
-- local checks passed
+- full local QA gate passed (\`make qa-local\`)
 - diff reviewed
 - no private drafts or secrets included
 - PR title/body look correct
 - changed files and URLs are expected
 EOF
-printf 'Merge this PR to main? [y/N] '
+printf 'Integrate this PR to main with rebase? [y/N] '
 read -r confirm
 if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
-  echo "merge cancelled"
+  echo "integration cancelled"
   exit 1
 fi
 

--- a/scripts/lib/tooling.sh
+++ b/scripts/lib/tooling.sh
@@ -39,3 +39,29 @@ require_repo_pre_commit() {
 
   printf '%s\n' "$pre_commit_bin"
 }
+
+repo_common_ancestor() {
+  git merge-base main HEAD 2>/dev/null || true
+}
+
+repo_merge_base() {
+  repo_common_ancestor
+}
+
+repo_changed_files() {
+  local common_ancestor
+  common_ancestor="$(repo_common_ancestor)"
+
+  if [[ -n "$common_ancestor" ]]; then
+    git diff --name-only --diff-filter=ACMR "$common_ancestor"...HEAD
+  fi
+
+  git ls-files --others --exclude-standard
+}
+
+repo_site_facing_changes() {
+  repo_changed_files |
+    awk 'NF' |
+    grep -E '^(_config\.yml|_includes/|_layouts/|_pages/|_posts/|assets/|_sass/)' ||
+    true
+}

--- a/scripts/publish-draft.sh
+++ b/scripts/publish-draft.sh
@@ -62,4 +62,4 @@ RUBY
 STRICT_POST_METADATA=1 "$repo_root/.agents/skills/jekyll-post-publisher/scripts/validate-post.sh" "$target_path"
 
 echo "published draft to: $target_path"
-echo "next: make check"
+echo "next: make qa-local"

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -4,13 +4,16 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+# shellcheck disable=SC1091
+. "$repo_root/scripts/lib/tooling.sh"
+
 export BUNDLE_PATH="$repo_root/vendor/bundle"
 export BUNDLE_FROZEN="true"
 
 validator="$repo_root/.agents/skills/jekyll-post-publisher/scripts/validate-post.sh"
 
-merge_base="$(git merge-base main HEAD 2>/dev/null || printf '')"
-tracked_changed="$(if [[ -n "$merge_base" ]]; then git diff --name-only --diff-filter=ACMR "$merge_base"...HEAD -- '_posts/*.md'; fi)"
+common_ancestor="$(repo_common_ancestor)"
+tracked_changed="$(if [[ -n "$common_ancestor" ]]; then git diff --name-only --diff-filter=ACMR "$common_ancestor"...HEAD -- '_posts/*.md'; fi)"
 untracked_changed="$(git ls-files --others --exclude-standard -- '_posts/*.md')"
 
 while IFS= read -r file; do

--- a/scripts/run-codex-checks.sh
+++ b/scripts/run-codex-checks.sh
@@ -75,6 +75,23 @@ errors << "missing .codex/prompts directory" unless Dir.exist?(prompt_dir)
   errors << "missing #{prompt_path.delete_prefix("#{repo_root}/")}" unless File.file?(prompt_path)
 end
 
+%w[site-workflow.md medium-to-blog.md].each do |prompt|
+  prompt_path = File.join(prompt_dir, prompt)
+  errors << "missing #{prompt_path.delete_prefix("#{repo_root}/")}" unless File.file?(prompt_path)
+end
+
+codex_usage = File.read(File.join(repo_root, ".codex", "docs", "codex-usage.md"))
+docs_readme = File.read(File.join(repo_root, ".codex", "docs", "README.md"))
+
+[
+  "@.codex/prompts/site-workflow.md",
+  "@.codex/prompts/editorial-workflow.md",
+  "@.codex/prompts/medium-to-blog.md"
+].each do |needle|
+  errors << "missing #{needle} in .codex/docs/codex-usage.md" unless codex_usage.include?(needle)
+  errors << "missing #{needle} in .codex/docs/README.md" unless docs_readme.include?(needle)
+end
+
 if errors.empty?
   puts "codex workflow checks passed"
   puts "validated skills: #{skill_paths.length}"

--- a/scripts/run-codex-checks.sh
+++ b/scripts/run-codex-checks.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+ruby - "$repo_root" <<'RUBY'
+require "date"
+require "yaml"
+
+repo_root = ARGV.fetch(0)
+errors = []
+
+skill_paths = Dir[File.join(repo_root, ".agents", "skills", "*")].select { |path| File.directory?(path) }.sort
+
+if skill_paths.empty?
+  errors << "no skill directories found under .agents/skills"
+end
+
+skill_paths.each do |skill_path|
+  skill_md = File.join(skill_path, "SKILL.md")
+  skill_label = skill_path.delete_prefix("#{repo_root}/")
+
+  unless File.file?(skill_md)
+    errors << "missing SKILL.md in #{skill_label}"
+    next
+  end
+
+  content = File.read(skill_md)
+  match = content.match(/\A---\s*\n(.*?)\n---\s*\n/m)
+  if match.nil?
+    errors << "missing YAML front matter in #{skill_label}/SKILL.md"
+  else
+    data = YAML.safe_load(match[1], permitted_classes: [Time, Date], aliases: true) || {}
+    errors << "missing name in #{skill_label}/SKILL.md" if data["name"].to_s.strip.empty?
+    errors << "missing description in #{skill_label}/SKILL.md" if data["description"].to_s.strip.empty?
+  end
+
+  openai_yaml = File.join(skill_path, "agents", "openai.yaml")
+  unless File.file?(openai_yaml)
+    errors << "missing agents/openai.yaml in #{skill_label}"
+    next
+  end
+
+  openai = YAML.safe_load(File.read(openai_yaml), permitted_classes: [Time, Date], aliases: true) || {}
+  interface = openai["interface"]
+  unless interface.is_a?(Hash)
+    errors << "missing interface block in #{skill_label}/agents/openai.yaml"
+    next
+  end
+
+  %w[display_name short_description default_prompt].each do |field|
+    errors << "missing interface.#{field} in #{skill_label}/agents/openai.yaml" if interface[field].to_s.strip.empty?
+  end
+end
+
+makefile = File.read(File.join(repo_root, "Makefile"))
+%w[site-audit codex-check qa-local].each do |target|
+  errors << "missing #{target} target in Makefile" unless makefile.match?(/^#{Regexp.escape(target)}:/)
+end
+
+docs_index = File.read(File.join(repo_root, ".codex", "docs", "README.md"))
+{
+  "[Codex Usage](./codex-usage.md)" => ".codex/docs/codex-usage.md",
+  "[Site Quality](./site-quality.md)" => ".codex/docs/site-quality.md"
+}.each do |needle, path|
+  errors << "missing docs index entry for #{path}" unless docs_index.include?(needle)
+end
+
+prompt_dir = File.join(repo_root, ".codex", "prompts")
+errors << "missing .codex/prompts directory" unless Dir.exist?(prompt_dir)
+
+%w[editorial-workflow.md site-quality.md repo-workflow.md official-docs.md].each do |prompt|
+  prompt_path = File.join(prompt_dir, prompt)
+  errors << "missing #{prompt_path.delete_prefix("#{repo_root}/")}" unless File.file?(prompt_path)
+end
+
+if errors.empty?
+  puts "codex workflow checks passed"
+  puts "validated skills: #{skill_paths.length}"
+else
+  errors.each { |error| warn "error: #{error}" }
+  exit 1
+end
+RUBY

--- a/scripts/run-lint.sh
+++ b/scripts/run-lint.sh
@@ -8,8 +8,8 @@ cd "$repo_root"
 
 pre_commit_bin="$(require_repo_pre_commit)"
 
-merge_base="$(git merge-base main HEAD 2>/dev/null || printf '')"
-tracked_changed="$(if [[ -n "$merge_base" ]]; then git diff --name-only --diff-filter=ACMR "$merge_base"...HEAD; fi)"
+common_ancestor="$(repo_common_ancestor)"
+tracked_changed="$(if [[ -n "$common_ancestor" ]]; then git diff --name-only --diff-filter=ACMR "$common_ancestor"...HEAD; fi)"
 untracked_changed="$(git ls-files --others --exclude-standard)"
 changed_files="$(
   printf '%s\n%s\n' "$tracked_changed" "$untracked_changed" |

--- a/scripts/run-local-qa.sh
+++ b/scripts/run-local-qa.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# shellcheck disable=SC1091
+. "$repo_root/scripts/lib/tooling.sh"
+
+run_step() {
+  local label="$1"
+  shift
+  echo "==> $label"
+  "$@"
+}
+
+run_step "Linting repo automation and docs" make lint
+run_step "Running security checks" make security
+run_step "Validating Codex skills, prompts, and docs" make codex-check
+run_step "Running site SEO audit" make site-audit AUDIT=seo TARGET=site
+run_step "Running site quality audit" make site-audit AUDIT=quality TARGET=site
+run_step "Running site maintenance audit" make site-audit AUDIT=maintenance TARGET=site
+run_step "Running tracked repo validation" make check
+
+site_changes="$(repo_site_facing_changes)"
+if [[ -n "$site_changes" ]]; then
+  cat <<EOF
+Manual preview required before commit because site-facing files changed:
+$site_changes
+
+Preview flow:
+1. bundle exec jekyll serve
+2. Open the affected pages in the browser
+3. Spot-check layout, metadata-sensitive pages, and navigation
+4. Commit only after the preview is clean
+EOF
+fi
+
+echo "local QA gate passed"

--- a/scripts/run-security-checks.sh
+++ b/scripts/run-security-checks.sh
@@ -9,26 +9,12 @@ cd "$repo_root"
 pre_commit_bin="$(require_repo_pre_commit)"
 export SEMGREP_ENABLE_VERSION_CHECK=0
 export SEMGREP_SEND_METRICS=off
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-/tmp/semgrep-state}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/tmp/semgrep-state}"
+export SEMGREP_LOG_FILE="${SEMGREP_LOG_FILE:-/tmp/semgrep-state/semgrep.log}"
+export SEMGREP_SETTINGS_FILE="${SEMGREP_SETTINGS_FILE:-/tmp/semgrep-state/settings.yml}"
+export SEMGREP_VERSION_CACHE_PATH="${SEMGREP_VERSION_CACHE_PATH:-/tmp/semgrep-state/version-cache}"
 
-semgrep_targets=()
+mkdir -p "${XDG_CONFIG_HOME}" "${XDG_CACHE_HOME}"
 
-if command -v rg >/dev/null 2>&1; then
-  while IFS= read -r target; do
-    [[ -n "$target" ]] || continue
-    semgrep_targets+=("$target")
-  done < <(rg --files scripts .agents .github/workflows -g '*.sh' -g '*.yml' -g '*.yaml')
-else
-  while IFS= read -r target; do
-    [[ -n "$target" ]] || continue
-    semgrep_targets+=("${target#./}")
-  done < <(
-    find scripts .agents .github/workflows \
-      \( -name '*.sh' -o -name '*.yml' -o -name '*.yaml' \) \
-      -type f \
-      | sort
-  )
-fi
-
-semgrep_targets=(.semgrep.yml "${semgrep_targets[@]}")
-
-"$pre_commit_bin" run semgrep --files "${semgrep_targets[@]}"
+"$pre_commit_bin" run semgrep --all-files

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -112,5 +112,5 @@ Local setup complete.
 
 Next steps:
 - make validate-draft PATH=_drafts/example.md
-- make check
+- make qa-local
 EOF

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -12,6 +12,7 @@ cat <<'EOF'
 Installed git hooks.
 
 Useful commands:
+- make qa-local
 - ./.venv-tools/bin/pre-commit run --all-files
 - ./.venv-tools/bin/pre-commit run --hook-stage pre-push --all-files
 EOF

--- a/scripts/site-audit.sh
+++ b/scripts/site-audit.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+audit="${AUDIT:-${1:-}}"
+target="${TARGET:-${2:-site}}"
+
+if [[ -z "$audit" ]]; then
+  echo "error: provide AUDIT=seo|performance|quality|maintenance or pass it as the first argument" >&2
+  exit 1
+fi
+
+case "$audit" in
+  seo|performance|quality|maintenance)
+    ;;
+  *)
+    echo "error: AUDIT must be one of: seo, performance, quality, maintenance" >&2
+    exit 1
+    ;;
+esac
+
+ruby - "$repo_root" "$audit" "$target" <<'RUBY'
+require "date"
+require "yaml"
+
+repo_root, audit, target = ARGV
+
+Finding = Struct.new(:severity, :scope, :message, :path, keyword_init: true)
+SEVERITY_ORDER = { "error" => 0, "warning" => 1, "note" => 2 }.freeze
+
+def relative_path(repo_root, path)
+  path.delete_prefix("#{repo_root}/")
+end
+
+def load_frontmatter(path)
+  content = File.read(path)
+  match = content.match(/\A---\s*\n(.*?)\n---\s*\n/m)
+  data =
+    if match
+      YAML.safe_load(match[1], permitted_classes: [Time, Date], aliases: true) || {}
+    else
+      nil
+    end
+  [content, data]
+end
+
+def markdown_candidates(repo_root)
+  Dir[File.join(repo_root, "_pages", "**", "*.md")].sort +
+    Dir[File.join(repo_root, "_posts", "**", "*.md")].sort
+end
+
+def resolve_target(repo_root, target)
+  if target == "site"
+    files = %w[
+      _pages/about.md
+      _pages/posts.md
+      _pages/tag-archive.md
+      _pages/category-archive.md
+      _pages/year-archive.md
+      _pages/404.md
+    ].map { |path| File.join(repo_root, path) }.select { |path| File.file?(path) }
+    return ["site", files]
+  end
+
+  candidate = File.expand_path(target, repo_root)
+  return [target, [candidate]] if File.file?(candidate)
+  return [target, Dir[File.join(candidate, "**", "*.md")].sort] if Dir.exist?(candidate)
+
+  if target.start_with?("/")
+    match = markdown_candidates(repo_root).find do |path|
+      _, data = load_frontmatter(path)
+      next false unless data
+
+      data["permalink"].to_s.strip == target
+    end
+    raise "could not resolve URL path #{target}" unless match
+
+    return [target, [match]]
+  end
+
+  raise "TARGET must be 'site', a repo path, or a URL path starting with /"
+end
+
+def add_finding(findings, severity, scope, message, path = nil)
+  findings << Finding.new(severity: severity, scope: scope, message: message, path: path)
+end
+
+def inspect_front_matter(findings, repo_root, path, data)
+  rel = relative_path(repo_root, path)
+  if data.nil?
+    add_finding(findings, "error", "frontmatter", "missing YAML front matter", rel)
+    return
+  end
+
+  add_finding(findings, "error", "frontmatter", "missing title", rel) if data["title"].to_s.strip.empty?
+  add_finding(findings, "warning", "frontmatter", "missing description", rel) if data["description"].to_s.strip.empty?
+
+  robots = data["robots"].to_s
+  sitemap = data["sitemap"]
+  if robots.match?(/noindex/i) && sitemap == true
+    add_finding(findings, "warning", "indexing", "noindex page is still marked for sitemap inclusion", rel)
+  end
+end
+
+config_path = File.join(repo_root, "_config.yml")
+head_path = File.join(repo_root, "_includes", "head", "custom.html")
+json_ld_path = File.join(repo_root, "_includes", "json-ld.html")
+makefile_path = File.join(repo_root, "Makefile")
+run_checks_path = File.join(repo_root, "scripts", "run-checks.sh")
+
+findings = []
+
+unless File.file?(config_path)
+  add_finding(findings, "error", "repo", "missing _config.yml", "_config.yml")
+end
+unless File.file?(head_path)
+  add_finding(findings, "error", "repo", "missing _includes/head/custom.html", "_includes/head/custom.html")
+end
+unless File.file?(json_ld_path)
+  add_finding(findings, "error", "repo", "missing _includes/json-ld.html", "_includes/json-ld.html")
+end
+
+label, target_files = resolve_target(repo_root, target)
+
+config = File.file?(config_path) ? (YAML.load_file(config_path) || {}) : {}
+plugins = Array(config["plugins"])
+includes = Array(config["include"])
+head = File.file?(head_path) ? File.read(head_path) : ""
+json_ld = File.file?(json_ld_path) ? File.read(json_ld_path) : ""
+makefile = File.file?(makefile_path) ? File.read(makefile_path) : ""
+run_checks = File.file?(run_checks_path) ? File.read(run_checks_path) : ""
+
+case audit
+when "seo"
+  add_finding(findings, "error", "seo", "jekyll-seo-tag plugin is not enabled", "_config.yml") unless plugins.include?("jekyll-seo-tag")
+  add_finding(findings, "error", "seo", "jekyll-sitemap plugin is not enabled", "_config.yml") unless plugins.include?("jekyll-sitemap")
+  add_finding(findings, "error", "seo", "site.url is missing", "_config.yml") if config["url"].to_s.strip.empty?
+  add_finding(findings, "error", "seo", "custom head is missing `{% seo %}`", "_includes/head/custom.html") unless head.include?("{% seo %}")
+  add_finding(findings, "warning", "seo", "custom head does not include json-ld partial", "_includes/head/custom.html") unless head.include?("{% include json-ld.html %}")
+  add_finding(findings, "warning", "seo", "json-ld partial is missing schema.org context", "_includes/json-ld.html") unless json_ld.include?('"@context": "https://schema.org"')
+  add_finding(findings, "warning", "seo", "json-ld partial is missing BlogPosting schema", "_includes/json-ld.html") unless json_ld.include?('"@type": "BlogPosting"')
+  if head.include?("{% seo %}") && head.include?('<meta property="og:title"')
+    add_finding(findings, "warning", "seo", "custom head duplicates Open Graph metadata on top of `{% seo %}`", "_includes/head/custom.html")
+  end
+  if head.include?("{% seo %}") && head.include?('<meta name="twitter:title"')
+    add_finding(findings, "warning", "seo", "custom head duplicates Twitter card metadata on top of `{% seo %}`", "_includes/head/custom.html")
+  end
+
+  target_files.each do |path|
+    _, data = load_frontmatter(path)
+    inspect_front_matter(findings, repo_root, path, data)
+
+    next unless data
+    rel = relative_path(repo_root, path)
+    if File.basename(path) == "404.md"
+      add_finding(findings, "warning", "seo", "404 page should set sitemap: false", rel) unless data["sitemap"] == false
+      add_finding(findings, "warning", "seo", "404 page should set robots to noindex", rel) unless data["robots"].to_s.match?(/noindex/i)
+    end
+  end
+when "performance"
+  if head.include?("mermaid.min.js")
+    add_finding(findings, "warning", "performance", "Mermaid is loaded globally from a CDN on every page", "_includes/head/custom.html")
+  end
+  if head.include?("goatcounter")
+    add_finding(findings, "note", "performance", "GoatCounter analytics script loads on every page", "_includes/head/custom.html")
+  end
+  if head.include?("cdn.jsdelivr.net")
+    add_finding(findings, "warning", "performance", "A jsDelivr asset is loaded globally; review cache and critical path impact", "_includes/head/custom.html")
+  end
+
+  oversized_images = Dir[File.join(repo_root, "assets", "images", "**", "*")].select do |path|
+    File.file?(path) && File.size(path) > 500_000
+  end.sort_by { |path| -File.size(path) }
+
+  oversized_images.first(5).each do |path|
+    add_finding(
+      findings,
+      "warning",
+      "performance",
+      format("large local image asset (%<kb>.1f KB)", kb: File.size(path) / 1024.0),
+      relative_path(repo_root, path)
+    )
+  end
+when "quality"
+  add_finding(findings, "error", "quality", "_pages is not included in the Jekyll build config", "_config.yml") unless includes.include?("_pages")
+  add_finding(findings, "warning", "quality", "custom head does not include json-ld partial", "_includes/head/custom.html") unless head.include?("{% include json-ld.html %}")
+
+  target_files.each do |path|
+    _, data = load_frontmatter(path)
+    inspect_front_matter(findings, repo_root, path, data)
+    next unless data
+
+    rel = relative_path(repo_root, path)
+    add_finding(findings, "warning", "quality", "missing layout", rel) if data["layout"].to_s.strip.empty?
+    if File.basename(path) == "404.md"
+      add_finding(findings, "warning", "quality", "404 page should set sitemap: false", rel) unless data["sitemap"] == false
+      add_finding(findings, "warning", "quality", "404 page should set robots to noindex", rel) unless data["robots"].to_s.match?(/noindex/i)
+    end
+  end
+when "maintenance"
+  if config["remote_theme"].to_s.strip != ""
+    add_finding(
+      findings,
+      "warning",
+      "maintenance",
+      "remote_theme is enabled; clean builds depend on fetching the theme when it is not already cached",
+      "_config.yml"
+    )
+  end
+
+  if head.match?(%r{https://})
+    add_finding(findings, "warning", "maintenance", "custom head includes third-party scripts or assets; review them during site maintenance", "_includes/head/custom.html")
+  end
+
+  if run_checks.include?("bundle exec jekyll build") && config["remote_theme"].to_s.strip != ""
+    add_finding(findings, "note", "maintenance", "make check requires a successful Jekyll build and may need network access for the remote theme", "scripts/run-checks.sh")
+  end
+
+  %w[site-audit codex-check qa-local].each do |target_name|
+    add_finding(findings, "error", "maintenance", "missing #{target_name} Make target", "Makefile") unless makefile.match?(/^#{Regexp.escape(target_name)}:/)
+  end
+end
+
+ordered = findings.sort_by { |finding| [SEVERITY_ORDER.fetch(finding.severity), finding.scope, finding.path.to_s, finding.message] }
+error_count = ordered.count { |finding| finding.severity == "error" }
+
+puts "Audit: #{audit}"
+puts "Target: #{label}"
+
+if ordered.empty?
+  puts "No findings."
+else
+  ordered.each do |finding|
+    location = finding.path ? " (#{finding.path})" : ""
+    puts "[#{finding.severity.upcase}] #{finding.scope}: #{finding.message}#{location}"
+  end
+end
+
+puts "Summary: #{error_count} error(s), #{ordered.count { |finding| finding.severity == "warning" }} warning(s), #{ordered.count { |finding| finding.severity == "note" }} note(s)"
+exit 1 if error_count.positive?
+RUBY

--- a/scripts/start-work.sh
+++ b/scripts/start-work.sh
@@ -38,8 +38,8 @@ if ! git fetch "$main_remote" "$main_remote_branch" --quiet; then
   exit 1
 fi
 
-git merge --ff-only "$main_remote/$main_remote_branch" >/dev/null
+git rebase "$main_remote/$main_remote_branch" >/dev/null
 git checkout -b "$branch_name"
 
 echo "created branch: $branch_name"
-echo "next: make check"
+echo "next: implement the change, then run make qa-local"


### PR DESCRIPTION
## Summary

- codex workflow and site qa hardening

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Validation

- `make qa-local`

## Affected Files

```text
.agents/skills/official-doc-verifier/SKILL.md
.agents/skills/official-doc-verifier/references/context7-lookup.md
.agents/skills/official-doc-verifier/references/research-sequencing.md
.agents/skills/repo-flow/SKILL.md
.agents/skills/repo-flow/agents/openai.yaml
.agents/skills/repo-flow/references/branch-pr-merge.md
.agents/skills/site-quality-auditor/SKILL.md
.agents/skills/site-quality-auditor/agents/openai.yaml
.agents/skills/site-quality-auditor/references/maintenance.md
.agents/skills/site-quality-auditor/references/performance.md
.agents/skills/site-quality-auditor/references/quality.md
.agents/skills/site-quality-auditor/references/seo.md
.codex/docs/README.md
.codex/docs/ai-workflow.md
.codex/docs/codex-usage.md
.codex/docs/prompt-recipes.md
.codex/docs/site-quality.md
.codex/docs/tooling.md
.codex/docs/workflows.md
.codex/prompts/editorial-workflow.md
.codex/prompts/official-docs.md
.codex/prompts/repo-workflow.md
.codex/prompts/site-quality.md
.pre-commit-config.yaml
.semgrep.yml
AGENTS.md
Makefile
README.md
scripts/create-pr.sh
scripts/finalize-merge.sh
scripts/lib/tooling.sh
scripts/publish-draft.sh
scripts/run-checks.sh
scripts/run-codex-checks.sh
scripts/run-lint.sh
scripts/run-local-qa.sh
scripts/run-security-checks.sh
scripts/setup-dev.sh
scripts/setup-hooks.sh
scripts/site-audit.sh
scripts/start-work.sh
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
