### PR TITLE
feat: editorial preservation workflow hardening

### DIFF
--- a/.agents/skills/fact-checker/SKILL.md
+++ b/.agents/skills/fact-checker/SKILL.md
@@ -12,8 +12,11 @@ Use this skill when content accuracy matters.
 1. Read `references/source-policy.md`.
 2. Read `references/citation-format.md`.
 3. Use Context7 whenever the official docs are available there and exact behavior matters.
-4. If the piece is still outline-only or structurally weak, send it to `technical-post-drafter` before spending time on detailed verification.
-5. Return the checked draft to `jekyll-post-publisher` for metadata, QA, and publication.
+4. If the piece is in a preservation-first workflow, treat fact-checking as advisory unless the
+   user explicitly approves text edits.
+5. If the piece is still outline-only or structurally weak, send it to `technical-post-drafter`
+   before spending time on detailed verification.
+6. Return the checked draft to `jekyll-post-publisher` for metadata, QA, and publication.
 
 ## Output Expectations
 
@@ -32,3 +35,5 @@ Use this skill when content accuracy matters.
 - Prefer primary sources.
 - Do not rely on memory for version-sensitive claims when official docs are available.
 - Surface unsupported, stale, or ambiguous claims clearly.
+- In faithful Medium ports or historical-preservation edits, do not silently rewrite historically
+  protected text.

--- a/.agents/skills/historical-post-editor/SKILL.md
+++ b/.agents/skills/historical-post-editor/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: historical-post-editor
+description: Safely improve styling, media, and SEO for an existing published post while preserving its title, description, publish date, filename date, and prose body by default.
+---
+
+# Historical Post Editor
+
+Use this skill when editing an existing tracked post without changing its historical text or dates.
+
+## Workflow
+
+1. Read `references/preservation-rules.md`.
+2. Read `references/media-caption-style.md` when the post includes editorial images, credits, or
+   subtitles.
+3. Read `references/seo-safe-edits.md` when metadata, canonical tags, or social images are part of
+   the task.
+4. Snapshot the protected fields before editing.
+5. Make only preservation-safe changes unless the user explicitly asks for text or date edits.
+6. Run `scripts/assert-protected-post-fields.sh` before calling the work done.
+
+## Output Expectations
+
+- protected fields preserved by default
+- media blocks normalized to the repo's standard figure/caption pattern
+- SEO and rendering fixes applied without historical drift
+
+## Rules
+
+- Protect the post title, description, publish date, filename date, and prose body by default.
+- Use inline `figure.post-figure` and `figcaption` for editorial media.
+- Keep captions smaller, italic, and visually subordinate to body text.
+- Do not promote inline images into hero overlays unless the user explicitly asks for that change.

--- a/.agents/skills/historical-post-editor/agents/openai.yaml
+++ b/.agents/skills/historical-post-editor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Historical Post Editor"
+  short_description: "Improve existing posts without changing their historical text or dates"
+  default_prompt: "Use $historical-post-editor to update this published post's media, styling, or SEO while preserving its title, description, date, and prose."

--- a/.agents/skills/historical-post-editor/references/media-caption-style.md
+++ b/.agents/skills/historical-post-editor/references/media-caption-style.md
@@ -1,0 +1,25 @@
+# Media Caption Style
+
+Use this standard article-media pattern for preserved posts:
+
+```html
+<figure class="post-figure">
+  <img src="..." alt="...">
+  <figcaption>Caption or credit text.</figcaption>
+</figure>
+```
+
+Rules:
+
+- keep the image inline in article flow
+- keep the caption attached directly below the image
+- use `figcaption` for photo credit, image subtitle, or AI-generated-image note
+- do not leave caption text as a standalone paragraph
+- do not convert the image into a hero overlay unless explicitly requested
+
+Design requirements:
+
+- caption is smaller than body text
+- caption is italic
+- caption color is slightly muted
+- caption links inherit the caption tone

--- a/.agents/skills/historical-post-editor/references/preservation-rules.md
+++ b/.agents/skills/historical-post-editor/references/preservation-rules.md
@@ -1,0 +1,24 @@
+# Preservation Rules
+
+For existing tracked posts in preservation mode:
+
+- freeze `title`
+- freeze `description`
+- freeze front matter `date`
+- freeze the `_posts/YYYY-MM-DD-...` filename date
+- freeze prose body text
+
+Allowed changes:
+
+- `last_modified_at`
+- categories and tags
+- image blocks and image sources
+- figure and figcaption markup
+- caption styling
+- SEO, schema, canonical, and social metadata
+- shared CSS or include fixes needed to support the post
+
+Before finishing:
+
+- compare the before and after versions with `scripts/assert-protected-post-fields.sh`
+- preview the affected post if rendering changed

--- a/.agents/skills/historical-post-editor/references/seo-safe-edits.md
+++ b/.agents/skills/historical-post-editor/references/seo-safe-edits.md
@@ -1,0 +1,10 @@
+# SEO Safe Edits
+
+For preservation-mode updates:
+
+- do not rewrite title or description for SEO without explicit approval
+- do not change publish dates for SEO reasons
+- improve OG, Twitter, JSON-LD, and canonical behavior without touching protected prose
+- validate remote image behavior in both visible rendering and metadata output
+- if the exact original image is unavailable, a relevant fallback image is acceptable when the user
+  has allowed it

--- a/.agents/skills/jekyll-post-publisher/SKILL.md
+++ b/.agents/skills/jekyll-post-publisher/SKILL.md
@@ -33,10 +33,17 @@ Use this skill for repo-specific blog work.
 2. Read `references/content-checklist.md` for the publish bar.
 3. If the post includes an Unsplash image, read `references/cover-images.md`.
 4. If the post is a Medium migration, read `references/medium-migration.md`.
-5. If the content is still outline-only or the body needs major rewriting, hand it to `technical-post-drafter` before publish QA.
-6. If technical claims still need verification, run `fact-checker` before calling a draft publish-ready.
-7. Use `scripts/validate-post.sh <path>` before calling a post ready.
-8. Use `make validate-draft`, `make qa-publish`, and `make publish-draft` as the repo-level workflow.
+5. Determine the content mode:
+   - `net-new`
+   - `faithful-migration`
+   - `historical-preservation-edit`
+6. If the content is still outline-only or the body needs major rewriting, hand it to
+   `technical-post-drafter` before publish QA.
+7. If technical claims still need verification, run `fact-checker` before calling a draft
+   publish-ready.
+8. Use `scripts/validate-post.sh <path>` before calling a post ready.
+9. Use `make validate-draft`, `make qa-publish`, and `make publish-draft` as the repo-level
+   workflow for drafts.
 
 ## Output Expectations
 
@@ -59,4 +66,12 @@ Use this skill for repo-specific blog work.
 - Require `fact_check_status` before publish.
 - Prefer the controlled taxonomy in `references/taxonomy.md`.
 - Keep the author's voice intact; improve clarity and structure without flattening it.
+- In `faithful-migration` mode, preserve source date, title, description, prose, and media order
+  unless the user explicitly asks otherwise.
+- In `historical-preservation-edit` mode, do not rewrite title, description, publish date, or
+  prose body without explicit approval.
+- Visible media rendering and OG/Twitter/JSON-LD image behavior must both be checked when remote
+  images are involved.
+- Use inline `figure.post-figure` and `figcaption` for editorial media by default; hero overlays
+  are opt-in only.
 - Own file creation, metadata, validation, and publication; do not become the default body-drafting skill.

--- a/.agents/skills/jekyll-post-publisher/references/medium-migration.md
+++ b/.agents/skills/jekyll-post-publisher/references/medium-migration.md
@@ -2,8 +2,11 @@
 
 When migrating a Medium post:
 
-- preserve the original voice and thesis
-- improve formatting, structure, metadata, and readability
-- avoid turning the migration into a full rewrite unless asked
-- re-check technical claims that may have drifted
-- make the post feel native to this site rather than exported from another platform
+- default to preserving the original publish date, title, description, prose body, and media order
+- improve markup, metadata, and rendering without changing historically protected text
+- exact source images are preferred, but relevant fallback images are allowed when the original is
+  blocked or unavailable
+- use inline `figure.post-figure` and `figcaption` as the default rendering fix for imported media
+- do not use hero or header image treatments unless explicitly requested
+- re-check technical claims that may have drifted, but treat the findings as advisory unless the
+  user explicitly asks for body edits

--- a/.agents/skills/medium-porter/SKILL.md
+++ b/.agents/skills/medium-porter/SKILL.md
@@ -11,24 +11,30 @@ Use this skill when importing or cleaning up Medium-origin content.
 
 1. Read `references/migration-checklist.md`.
 2. Read `references/canonical-seo.md`.
-3. Reuse the site's standard front matter and taxonomy conventions.
-4. If the imported article still feels structurally weak or overly Medium-native, hand it to `technical-post-drafter` before final fact checking and publication.
+3. Default to `faithful-port` mode unless the user explicitly asks for a rewrite or site-native
+   adaptation.
+4. Reuse the site's standard front matter and taxonomy conventions.
+5. If the user explicitly wants a site-native rewrite, hand the draft to `technical-post-drafter`
+   before final fact checking and publication.
 
 ## Output Expectations
 
 - a site-native draft or post
 - normalized metadata
-- preserved voice with improved structure
+- preserved historical text and dates by default
 - any follow-up fact-check or SEO notes
 
 ## Done Criteria
 
-- the migrated article no longer feels like a raw Medium export
-- metadata and structure are consistent with the rest of the site
+- the migrated article preserves protected fields when in `faithful-port` mode
+- metadata and media handling are consistent with the rest of the site
 
 ## Rules
 
-- Preserve the original voice and thesis.
-- Improve structure, formatting, and metadata.
-- Re-check time-sensitive technical claims.
+- Preserve the original publish date, title, description, prose body, and media order by default.
+- Exact source media is preferred, but a different relevant image is allowed when the original is
+  blocked or unavailable.
+- Render article media inline with the standard `figure.post-figure` and `figcaption` pattern.
+- Re-check time-sensitive technical claims, but treat the results as advisory unless the user
+  explicitly approves content edits.
 - Avoid large rewrites unless the user explicitly asks for one.

--- a/.agents/skills/medium-porter/references/canonical-seo.md
+++ b/.agents/skills/medium-porter/references/canonical-seo.md
@@ -3,5 +3,8 @@
 When migrating Medium content:
 
 - decide whether canonical references need to change
-- ensure the site's description and cover image are stronger than the Medium original
+- preserve historically protected text unless the user explicitly asks for modernization
+- exact source images are preferred, but relevant fallback images are acceptable when the original
+  is blocked or unavailable
+- treat image metadata and visible media presentation as separate checks
 - avoid carrying over Medium-specific formatting or callout patterns that do not fit the site

--- a/.agents/skills/medium-porter/references/migration-checklist.md
+++ b/.agents/skills/medium-porter/references/migration-checklist.md
@@ -1,12 +1,17 @@
 # Migration Checklist
 
-- preserve the thesis
-- preserve the voice
-- refresh title and description when needed
+- confirm whether the task is `faithful-port` or explicit site-native adaptation
+- capture the original publish date, title, description, prose body, and media order
+- preserve publish date and filename date in `faithful-port` mode
+- preserve title, description, and prose body in `faithful-port` mode
 - normalize front matter
 - normalize tags and categories
-- clean headings and code fences
-- review links and embeds
+- review links, embeds, and media order
 - add cover image metadata
-- verify time-sensitive claims
-- make the result feel native to the site
+- prefer the exact source image when recoverable
+- use a different but relevant image only when the original is blocked or unavailable
+- preserve caption intent and convert detached image notes into `figure.post-figure` and
+  `figcaption` where needed
+- do not use hero overlays by default
+- verify time-sensitive claims without silently rewriting preserved source text
+- preview the final article-media UX before publication

--- a/.codex/docs/codex-usage.md
+++ b/.codex/docs/codex-usage.md
@@ -34,6 +34,7 @@ file directly:
 - `@.codex/prompts/site-workflow.md`
 - `@.codex/prompts/editorial-workflow.md`
 - `@.codex/prompts/medium-to-blog.md`
+- `@.codex/prompts/preserve-existing-post.md`
 
 These are IDE file references to reusable prompt files in the repo. They are not built-in Codex
 slash commands.
@@ -65,6 +66,12 @@ Medium migration:
 
 ```text
 $medium-porter $fact-checker $jekyll-post-publisher $repo-flow
+```
+
+Existing post preservation edit:
+
+```text
+$historical-post-editor $site-quality-auditor $repo-flow
 ```
 
 If you want the repo prompt-file behavior in the app, paste the prompt file content into the
@@ -134,7 +141,7 @@ Turn this outline into a private draft in _drafts, fact-check the technical clai
 VS Code / Cursor:
 
 ```text
-@.codex/prompts/medium-to-blog.md Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, and open the PR: https://medium.com/example-post
+@.codex/prompts/medium-to-blog.md Faithfully port this Medium article into _posts while preserving the original date, title, description, prose body, and media order; if the exact source image is blocked, use a relevant replacement image, run QA, and open the PR: https://medium.com/example-post
 ```
 
 Codex app:
@@ -142,7 +149,23 @@ Codex app:
 ```text
 $medium-porter $fact-checker $jekyll-post-publisher $repo-flow
 
-Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, group clean commits, and open the PR: https://medium.com/example-post
+Faithfully port this Medium article into _posts while preserving the original date, title, description, prose body, and media order; if the exact source image is blocked, use a relevant replacement image, run QA, group clean commits, and open the PR: https://medium.com/example-post
+```
+
+### Preserve An Existing Published Post
+
+VS Code / Cursor:
+
+```text
+@.codex/prompts/preserve-existing-post.md Add a relevant inline image, convert image notes to styled figure captions, fix SEO metadata, keep the current title, description, publish date, and prose body unchanged, run QA, and open the PR: _posts/2025-10-01-example.md
+```
+
+Codex app:
+
+```text
+$historical-post-editor $site-quality-auditor $repo-flow
+
+Add a relevant inline image, convert image notes to styled figure captions, fix SEO metadata, keep the current title, description, publish date, and prose body unchanged, run QA, group clean commits, and open the PR: _posts/2025-10-01-example.md
 ```
 
 ## Scope Rules

--- a/.codex/prompts/editorial-workflow.md
+++ b/.codex/prompts/editorial-workflow.md
@@ -8,9 +8,14 @@ Use this repository's full net-new post workflow from topic or outline to publis
 - Use `$jekyll-post-publisher` for draft creation, front matter, validation, publish QA, and
   promotion into `_posts/`.
 - Use `$repo-flow` once tracked files exist and the work needs branch, commit, and PR packaging.
+- If the work is a Medium migration, use `.codex/prompts/medium-to-blog.md` instead.
+- If the work is an edit to an existing tracked post where the title, description, publish date,
+  and prose must stay intact, use `.codex/prompts/preserve-existing-post.md` instead.
 - Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=feat`.
 - Create or refine the private draft under `_drafts/`.
 - Ensure the draft has publish-ready metadata before publication.
+- Use the repo's standard article-media pattern for any editorial image blocks:
+  `figure.post-figure` with an attached `figcaption`.
 - Run:
   `make validate-draft PATH=_drafts/<draft>.md`
   `make qa-publish PATH=_drafts/<draft>.md`
@@ -19,5 +24,4 @@ Use this repository's full net-new post workflow from topic or outline to publis
 - Group clean Conventional Commits only after QA passes.
 - Re-run `make qa-local` on the committed tree.
 - Run `make create-pr TYPE=feat`.
-- If the work is actually a Medium migration, use `.codex/prompts/medium-to-blog.md` instead.
 - Finish only when the tracked post exists in `_posts/` and the PR is open.

--- a/.codex/prompts/medium-to-blog.md
+++ b/.codex/prompts/medium-to-blog.md
@@ -1,22 +1,35 @@
 # Medium To Blog
 
-Use this repository's full Medium migration workflow from source URL to published post and PR.
+Use this repository's preservation-first Medium migration workflow from source URL to published
+post and PR.
 
-- Use `$medium-porter` to convert the Medium article into a site-native draft while preserving
-  voice and thesis.
-- Use `$fact-checker` for technical or time-sensitive claims before publication.
+- Use `$medium-porter` in `faithful-port` mode by default.
+- Use `$fact-checker` for technical or time-sensitive claims, but treat the results as advisory
+  unless the user explicitly asks to rewrite the post.
 - Use `$jekyll-post-publisher` for front matter, validation, publish QA, and promotion into
   `_posts/`.
-- Use `$repo-flow` for branch creation, QA, commit grouping, and PR packaging.
+- Use `$repo-flow` for branch creation, grouped commits, QA, and PR packaging.
 - Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=feat`.
+- Capture and preserve the original:
+  - publish date
+  - title
+  - description
+  - prose body
+  - media order
+- Use a different but relevant image only when the exact original image cannot be recovered from
+  Medium or its source.
+- Render article media inline with the repo's standard `figure.post-figure` and `figcaption`
+  pattern. Do not use hero overlays unless the user explicitly asks for that presentation.
+- Do not rewrite body text, change publish dates, or change title/description unless the user
+  explicitly asks for adaptation.
 - Ingest the Medium URL and convert it into a private draft under `_drafts/`.
-- Adapt metadata, taxonomy, structure, and formatting to this repo.
 - Run:
   `make validate-draft PATH=_drafts/<draft>.md`
   `make qa-publish PATH=_drafts/<draft>.md`
   `make publish-draft PATH=_drafts/<draft>.md DATE=YYYY-MM-DD`
 - After `_posts/` is updated, run `make qa-local`.
-- Group clean Conventional Commits only after QA passes.
+- Group the work into multiple relevant Conventional Commits only after QA passes.
 - Re-run `make qa-local` on the committed tree.
 - Run `make create-pr TYPE=feat`.
-- Finish only when the tracked post exists in `_posts/` and the PR is open.
+- Finish only when the tracked post exists in `_posts/`, the preserved fields still match the
+  source, and the PR is open.

--- a/.codex/prompts/preserve-existing-post.md
+++ b/.codex/prompts/preserve-existing-post.md
@@ -1,0 +1,32 @@
+# Preserve Existing Post
+
+Use this repository's preservation-first workflow for improving an existing tracked post without
+changing its historical text or dates.
+
+- Use `$historical-post-editor` to make safe media, styling, and SEO improvements while freezing:
+  - title
+  - description
+  - publish date
+  - `_posts` filename date
+  - prose body text
+- Use `$site-quality-auditor` for SEO, quality, and maintenance checks when shared site files or
+  metadata behavior changes.
+- Use `$repo-flow` for branch creation, grouped commits, QA, and PR packaging.
+- Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=fix`.
+- Before editing, snapshot the protected post fields and verify they still match after the changes.
+- Allowed changes by default:
+  - add or replace a relevant inline image
+  - add or replace a relevant header image when explicitly requested
+  - convert image credit or subtitle text into `figure.post-figure` and `figcaption`
+  - apply the standard smaller italic caption styling
+  - fix OG, Twitter, JSON-LD, canonical, and related metadata behavior
+  - normalize media rendering bugs
+  - update categories, tags, and `last_modified_at` when appropriate
+- Do not rewrite title, description, publish date, or prose body unless the user explicitly asks.
+- Run `scripts/assert-protected-post-fields.sh` against the before and after versions when the
+  task is in preservation mode.
+- After the changes are complete, run `make qa-local`.
+- Group the work into multiple relevant Conventional Commits only after QA passes.
+- Re-run `make qa-local` on the committed tree.
+- Run `make create-pr TYPE=fix`.
+- Finish only when the protected fields are still intact and the PR is open.

--- a/_posts/2025-10-01-the-cost-of-ignoring-platform-power-in-mobile-development.md
+++ b/_posts/2025-10-01-the-cost-of-ignoring-platform-power-in-mobile-development.md
@@ -25,8 +25,13 @@ image_source: unsplash
 fact_check_status: complete
 ---
 
-Photo by [Kelly Sikkema](https://unsplash.com/@kellysikkema) on
-[Unsplash](https://unsplash.com/)
+<figure class="post-figure">
+  <img
+    src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80"
+    alt="Developer workspace with a laptop, phone, and code editor open on a desk"
+  >
+  <figcaption>Photo by <a href="https://unsplash.com/@kellysikkema">Kelly Sikkema</a> on <a href="https://unsplash.com/">Unsplash</a></figcaption>
+</figure>
 
 Fear mongering and negativity sells more. Truth is often more nuanced.
 
@@ -101,8 +106,13 @@ platforms.
 This creates the permanent tension: platforms push separation, application builders push
 convergence. That is why Liquid Glass and Material You look so different, and why they always will.
 
-The real battle isn’t Native vs Cross-Platform, it’s Separation vs Convergence (Image generated
-with help of AI)
+<figure class="post-figure">
+  <img
+    src="/assets/images/posts/2025-10-01-the-cost-of-ignoring-platform-power-in-mobile-development/separation-vs-convergence.svg"
+    alt="The Permanent Tension in Mobile Development"
+  >
+  <figcaption>The real battle isn’t Native vs Cross-Platform, it’s Separation vs Convergence (Image generated with help of AI)</figcaption>
+</figure>
 
 And it is not just the platforms. Each ecosystem has loyal users who are used to its design
 system. iOS users expect a different rhythm of navigation, controls, and motion than Android users

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -48,3 +48,25 @@ blockquote {
   border-left: 4px solid #4387ab !important;
   background-color: #383840 !important;
 }
+
+.post-figure {
+  margin: 0 0 1.5rem;
+}
+
+.post-figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.post-figure figcaption {
+  margin-top: 0.65rem;
+  font-size: 0.85em;
+  font-style: italic;
+  line-height: 1.5;
+  color: rgba(245, 245, 245, 0.78);
+}
+
+.post-figure figcaption a {
+  color: inherit;
+}

--- a/assets/images/posts/2025-10-01-the-cost-of-ignoring-platform-power-in-mobile-development/separation-vs-convergence.svg
+++ b/assets/images/posts/2025-10-01-the-cost-of-ignoring-platform-power-in-mobile-development/separation-vs-convergence.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 800" role="img" aria-labelledby="title desc">
+  <title id="title">The Permanent Tension in Mobile Development</title>
+  <desc id="desc">A diagram showing Apple and Google pushing separation, companies pushing convergence, and cross-platform frameworks in the middle.</desc>
+  <rect width="1600" height="800" fill="#f4f4f4"/>
+  <text x="800" y="110" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="34" font-weight="700" fill="#222">
+    The Permanent Tension in Mobile Development
+  </text>
+
+  <text x="170" y="360" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#222">Apple &amp; Google</text>
+  <text x="170" y="398" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#222">Separation</text>
+
+  <text x="1245" y="360" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#222">Companies</text>
+  <text x="1220" y="398" font-family="Arial, Helvetica, sans-serif" font-size="30" fill="#222">Convergence</text>
+
+  <line x1="170" y1="440" x2="565" y2="440" stroke="#111" stroke-width="5"/>
+  <polygon points="565,440 546,430 546,450" fill="#111"/>
+
+  <line x1="1430" y1="440" x2="1035" y2="440" stroke="#111" stroke-width="5"/>
+  <polygon points="1035,440 1054,430 1054,450" fill="#111"/>
+
+  <rect x="560" y="390" width="480" height="100" rx="18" fill="#ececec" stroke="#222" stroke-width="3"/>
+  <text x="800" y="430" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#222">
+    Cross-Platform Frameworks
+  </text>
+  <text x="800" y="468" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#222">
+    (RN / Flutter / KMM)
+  </text>
+</svg>

--- a/scripts/assert-protected-post-fields.sh
+++ b/scripts/assert-protected-post-fields.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+before_path="${1:-}"
+after_path="${2:-}"
+
+if [[ -z "$before_path" || -z "$after_path" ]]; then
+  echo "usage: $0 <before-post-path> <after-post-path>" >&2
+  exit 1
+fi
+
+ruby - "$before_path" "$after_path" <<'RUBY'
+require "date"
+require "yaml"
+
+def load_post(path)
+  abort("error: file not found: #{path}") unless File.file?(path)
+
+  content = File.read(path)
+  match = content.match(/\A---\s*\n(.*?)\n---\s*\n/m)
+  abort("error: missing YAML front matter in #{path}") unless match
+
+  data = YAML.safe_load(match[1], permitted_classes: [Time, Date], aliases: true) || {}
+  body = content.sub(match[0], "")
+
+  {
+    path: path,
+    basename_date: File.basename(path)[/\A(\d{4}-\d{2}-\d{2})-/, 1],
+    title: data["title"].to_s,
+    description: data["description"].to_s,
+    date: data["date"].to_s,
+    body: normalize_body(body)
+  }
+end
+
+def normalize_body(body)
+  normalized = body.dup
+  normalized.gsub!(/<figure\b[^>]*>(.*?)<\/figure>/m) do
+    figure_html = Regexp.last_match(1)
+    figure_html.scan(/<figcaption\b[^>]*>(.*?)<\/figcaption>/m).flatten
+      .map { |caption| caption.gsub(/<[^>]+>/, " ") }
+      .join(" ")
+  end
+  normalized.gsub!(/!\[[^\]]*\]\([^)]+\)/, " ")
+  normalized.gsub!(/<img\b[^>]*>/m, " ")
+  normalized.gsub!(/\[([^\]]+)\]\([^)]+\)/, '\1')
+  normalized.gsub!(/\s+/, " ")
+  normalized.strip
+end
+
+before = load_post(ARGV.fetch(0))
+after = load_post(ARGV.fetch(1))
+
+checks = {
+  "front matter date" => [before[:date], after[:date]],
+  "title" => [before[:title], after[:title]],
+  "description" => [before[:description], after[:description]],
+  "normalized prose body" => [before[:body], after[:body]]
+}
+
+if before[:basename_date] && after[:basename_date]
+  checks["filename date"] = [before[:basename_date], after[:basename_date]]
+end
+
+failures = checks.each_with_object([]) do |(label, values), acc|
+  acc << label unless values[0] == values[1]
+end
+
+unless failures.empty?
+  warn "error: protected post fields changed unexpectedly: #{failures.join(', ')}"
+  failures.each do |label|
+    before_value, after_value = checks.fetch(label)
+    warn "--- #{label} (before)"
+    warn before_value
+    warn "--- #{label} (after)"
+    warn after_value
+  end
+  exit 1
+end
+
+puts "protected post fields preserved: #{before[:path]} -> #{after[:path]}"
+RUBY

--- a/scripts/qa-publish.sh
+++ b/scripts/qa-publish.sh
@@ -14,6 +14,7 @@ fi
 "$repo_root/scripts/validate-draft.sh" "$draft_path"
 
 ruby - "$draft_path" <<'RUBY'
+require "date"
 require "yaml"
 
 path = ARGV.fetch(0)
@@ -21,7 +22,7 @@ content = File.read(path)
 match = content.match(/\A---\s*\n(.*?)\n---\s*\n/m)
 abort("error: missing YAML front matter in #{path}") unless match
 
-data = YAML.safe_load(match[1], permitted_classes: [Time], aliases: true) || {}
+data = YAML.safe_load(match[1], permitted_classes: [Time, Date], aliases: true) || {}
 body = content.sub(match[0], "")
 allowed_categories = %w[blog ios swift react-native ai architecture testing debugging leadership developer-tools]
 


### PR DESCRIPTION
## Summary

- editorial preservation workflow hardening

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Validation

- `make qa-local`

## Affected Files

```text
.agents/skills/fact-checker/SKILL.md
.agents/skills/historical-post-editor/SKILL.md
.agents/skills/historical-post-editor/agents/openai.yaml
.agents/skills/historical-post-editor/references/media-caption-style.md
.agents/skills/historical-post-editor/references/preservation-rules.md
.agents/skills/historical-post-editor/references/seo-safe-edits.md
.agents/skills/jekyll-post-publisher/SKILL.md
.agents/skills/jekyll-post-publisher/references/medium-migration.md
.agents/skills/medium-porter/SKILL.md
.agents/skills/medium-porter/references/canonical-seo.md
.agents/skills/medium-porter/references/migration-checklist.md
.codex/docs/codex-usage.md
.codex/prompts/editorial-workflow.md
.codex/prompts/medium-to-blog.md
.codex/prompts/preserve-existing-post.md
_posts/2025-10-01-the-cost-of-ignoring-platform-power-in-mobile-development.md
assets/css/main.scss
assets/images/posts/2025-10-01-the-cost-of-ignoring-platform-power-in-mobile-development/separation-vs-convergence.svg
scripts/assert-protected-post-fields.sh
scripts/qa-publish.sh
```

## Affected URLs

```text
/the-cost-of-ignoring-platform-power-in-mobile-development/
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
