### PR TITLE
chore: editorial skill system updates

### DIFF
--- a/.agents/skills/content-brainstormer/SKILL.md
+++ b/.agents/skills/content-brainstormer/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: content-brainstormer
-description: Generate and refine authority-first writing ideas for this site. Use when brainstorming posts, clustering themes, choosing hooks, building an editorial backlog, or selecting topics that strengthen the author's positioning.
+description: "Use this skill when the user wants to decide what to write next for this site by generating topics, angles, hooks, or backlog priorities. Apply it to net-new ideation, theme clustering, and editorial direction setting that strengthens the site's point of view, not article-body drafting, claim verification, voice rewrites, or post packaging."
 ---
 
 # Content Brainstormer
 
 Use this skill when the user is choosing what to write next.
 
+## Routing Boundaries
+
+- Use it for topic generation, angle selection, hooks, series clustering, and backlog prioritization.
+- Do not use it when the user already has enough material and needs the body written. Route that to `technical-post-drafter`.
+- Do not use it when the main task is verifying claims, adding citations, or checking freshness. Route that to `fact-checker`.
+- Do not use it for voice rewrites of existing prose. Route that to `sh-humanizer`.
+- Do not use it for front matter, validation, or publication steps. Route that to `jekyll-post-publisher`.
+
 ## Workflow
 
-1. Read `references/positioning.md`.
-2. Read `references/topic-selection.md`.
-3. Use `references/editorial-calendar.md` when turning ideas into a backlog.
-4. Hand the chosen angle and outline to `technical-post-drafter` when the user is ready to write the article body.
+1. Read `../../../.codex/docs/editorial-voice-profile.md`.
+2. Read `references/positioning.md`.
+3. Read `references/topic-selection.md`.
+4. Use `references/editorial-calendar.md` when turning ideas into a backlog.
+5. Hand the chosen angle and outline to `technical-post-drafter` when the user is ready to write the article body.
 
 ## Output Expectations
 
@@ -25,11 +34,13 @@ Use this skill when the user is choosing what to write next.
 ## Done Criteria
 
 - the user has a shortlist of ideas worth drafting
-- the recommended topic supports authority-building
+- the recommended topic supports the site's point of view and core themes
 - the outline is strong enough to hand to `technical-post-drafter`
 
 ## Rules
 
-- Bias toward authority-building, not generic traffic.
+- Bias toward insight-led editorial positioning, not generic traffic.
+- Start from recurring failure modes, mistaken assumptions, organizational pressure, or repeated system patterns.
 - Prefer topics grounded in real engineering judgment and lived experience.
-- Suggest hooks, tension, and structure, not just titles.
+- Suggest hooks, tension, mechanism, and implication, not just titles.
+- Let stronger positioning be the outcome, not the framing language.

--- a/.agents/skills/content-brainstormer/agents/openai.yaml
+++ b/.agents/skills/content-brainstormer/agents/openai.yaml
@@ -1,4 +1,7 @@
 interface:
   display_name: "Content Brainstormer"
-  short_description: "Develop authority-first post ideas and hooks"
+  short_description: "Develop insight-led post ideas and hooks"
   default_prompt: "Use $content-brainstormer to generate or sharpen blog topics for this site."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/content-brainstormer/evals/eval_queries.json
+++ b/.agents/skills/content-brainstormer/evals/eval_queries.json
@@ -1,0 +1,31 @@
+{
+  "skill_name": "content-brainstormer",
+  "train": {
+    "should_trigger": [
+      "Give me five experience-driven post ideas about mobile debugging and recommend one.",
+      "I want to build a backlog around platform power and mobile team boundaries. Suggest angles and hooks.",
+      "What should I write next if I want stronger positioning around AI engineering and systems thinking?",
+      "Cluster these rough themes into a six-week editorial backlog: debugging, architecture tradeoffs, platform leverage."
+    ],
+    "should_not_trigger": [
+      "Turn this outline into a full article body with H2s and transitions.",
+      "Verify whether these Swift Testing claims are still accurate before I publish.",
+      "Rewrite this section so it sounds more like me and less generic.",
+      "Add front matter and publish this draft into _posts_."
+    ]
+  },
+  "validation": {
+    "should_trigger": [
+      "Give me three post hooks about iOS build failures that expose a mistaken assumption and pick the strongest one.",
+      "I have notes on frontend framing hurting mobile teams. Help me choose the angle and outline direction.",
+      "Suggest insight-led article ideas from recurring failure modes in mobile release engineering.",
+      "Help me choose between these topics and turn the winner into a publishable outline direction."
+    ],
+    "should_not_trigger": [
+      "Improve section flow in this rough draft about mobile incidents.",
+      "Convert this Medium article into site-native Jekyll content.",
+      "Research gaps in this outline and add citation-ready notes.",
+      "Update this published post's figure markup without changing the prose."
+    ]
+  }
+}

--- a/.agents/skills/content-brainstormer/evals/evals.json
+++ b/.agents/skills/content-brainstormer/evals/evals.json
@@ -1,0 +1,28 @@
+{
+  "skill_name": "content-brainstormer",
+  "evals": [
+    {
+      "id": "insight-led-mobile-debugging",
+      "prompt": "I want five experience-driven post ideas about mobile debugging for my engineering blog. Pick one angle and give me a hook and outline direction.",
+      "expected_output": "A shortlist of at least five topic ideas grounded in real failure modes or mistaken assumptions, one recommended angle, at least one hook, and an outline direction that surfaces mechanism and consequence.",
+      "assertions": [
+        "Returns at least five distinct topic ideas",
+        "Names one recommended angle",
+        "Provides at least one hook anchored in tension, failure, or a mistaken assumption",
+        "Provides an outline direction that includes mechanism and consequence instead of a full article draft"
+      ]
+    },
+    {
+      "id": "backlog-cluster-from-recurring-failures",
+      "prompt": "I keep seeing the same failure modes around release engineering, platform boundaries, and debugging. Turn that into a backlog of post directions with one flagship recommendation.",
+      "expected_output": "A backlog-oriented set of post directions anchored in recurring engineering failure modes, with one flagship recommendation and a mechanism-driven rationale for why it matters.",
+      "assertions": [
+        "Grounds ideas in recurring engineering failures or tradeoffs",
+        "Includes at least one mechanism-driven reason the flagship recommendation matters",
+        "Includes backlog or sequencing guidance",
+        "Recommends one flagship direction",
+        "Avoids drifting into claim verification, full drafting, or publication packaging"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/content-brainstormer/references/editorial-calendar.md
+++ b/.agents/skills/content-brainstormer/references/editorial-calendar.md
@@ -5,12 +5,12 @@ Use a simple backlog structure when asked:
 - theme
 - angle
 - target audience
-- authority value
+- core failure mode or pressure point
 - required research
 - urgency
 
 Maintain a mix of:
 
-- flagship authority posts
+- cornerstone insight posts
 - practical tactical posts
 - migration or refreshed legacy posts

--- a/.agents/skills/content-brainstormer/references/positioning.md
+++ b/.agents/skills/content-brainstormer/references/positioning.md
@@ -1,12 +1,12 @@
 # Positioning
 
-The site should compound authority in:
+The site should deepen its point of view in:
 
 - mobile architecture
 - debugging and failure analysis
 - systems thinking
 - AI engineering
-- principal mobile engineering leadership
+- mobile engineering leadership
 - cross-platform strategy
 
 Ideas that do not strengthen those themes should be deprioritized unless the user explicitly wants a personal or experimental post.

--- a/.agents/skills/content-brainstormer/references/topic-selection.md
+++ b/.agents/skills/content-brainstormer/references/topic-selection.md
@@ -2,10 +2,16 @@
 
 Prefer topics that:
 
-- reflect real-world judgment
-- expose tradeoffs and design pressure
-- connect technical depth to strategic thinking
-- can produce a strong opinionated hook
-- distinguish the author's point of view
+- start from a recurring failure mode, mistaken assumption, or pressure point seen in real systems or teams
+- expose the mechanism behind the situation, not just the fix
+- show a visible technical, organizational, or strategic consequence
+- carry enough tension for a blunt, opinionated hook
+- distinguish the author's point of view without relying on role-signaling authority
+- reward dense, insight-led treatment rather than tutorial sequencing
 
-Avoid ideas that are generic, too trend-chasing, or interchangeable with commodity tutorial content.
+Avoid ideas that:
+
+- are generic, trend-chasing, or interchangeable with commodity tutorial content
+- need marketing language to sound important
+- only describe a tool or framework without a real failure mode, mechanism, or consequence
+- collapse into step-by-step instruction with no broader implication

--- a/.agents/skills/fact-checker/SKILL.md
+++ b/.agents/skills/fact-checker/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: fact-checker
-description: Verify technical and time-sensitive claims for blog content. Use when a post contains library, framework, API, tool, or product claims that should be checked against primary sources or official documentation before publication.
+description: "Use this skill when the user has a substantive draft or claim list and needs technical or time-sensitive assertions verified against primary sources before publication. Apply it to library, framework, API, tool, product, and version-sensitive claims, not ideation, net-new drafting, voice rewrites, or metadata packaging."
 ---
 
 # Fact Checker
 
 Use this skill when content accuracy matters.
+
+## Routing Boundaries
+
+- Use it after the substance exists and the question is whether specific claims are true, current, or supportable.
+- Do not use it for choosing topics or angles. Route that to `content-brainstormer`.
+- Do not use it for writing the main body from scratch or restructuring a weak draft. Route that to `technical-post-drafter`.
+- Do not use it for stylistic rewrites or voice polish. Route that to `sh-humanizer`.
+- Do not use it for front matter, publish QA, or promotion into `_posts/`. Route that to `jekyll-post-publisher`.
 
 ## Workflow
 

--- a/.agents/skills/fact-checker/agents/openai.yaml
+++ b/.agents/skills/fact-checker/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Fact Checker"
   short_description: "Verify technical claims with primary sources"
   default_prompt: "Use $fact-checker to verify the technical claims in this draft."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/fact-checker/evals/eval_queries.json
+++ b/.agents/skills/fact-checker/evals/eval_queries.json
@@ -1,0 +1,31 @@
+{
+  "skill_name": "fact-checker",
+  "train": {
+    "should_trigger": [
+      "Verify whether these Swift Testing and Context7 claims are still accurate before publish.",
+      "Check the version-sensitive claims in this draft against official docs.",
+      "I have a list of API and tool assertions. Tell me which ones are supported by primary sources.",
+      "Fact-check these library and product claims without rewriting the whole article."
+    ],
+    "should_not_trigger": [
+      "Turn this outline into a full technical article body.",
+      "Give me five experience-driven topic ideas about mobile debugging.",
+      "Rewrite this section so it sounds more like me and less like AI.",
+      "Add front matter and publish this draft into _posts_."
+    ]
+  },
+  "validation": {
+    "should_trigger": [
+      "Before I publish, verify whether these Jekyll, GitHub Actions, and OpenAI workflow claims are still current.",
+      "Check this draft for unsupported technical claims and tell me what needs citation or qualification.",
+      "Use primary sources to verify these framework and API statements.",
+      "Audit the technical claims in this article for freshness and source support."
+    ],
+    "should_not_trigger": [
+      "I copied this Medium article into the repo. Convert it into site-native content.",
+      "I need help choosing the best angle for a post about debugging culture.",
+      "This published post needs figure markup and SEO fixes, but the prose must stay unchanged.",
+      "I have an outline and sources. Help me improve the structure before I continue writing."
+    ]
+  }
+}

--- a/.agents/skills/fact-checker/evals/evals.json
+++ b/.agents/skills/fact-checker/evals/evals.json
@@ -1,0 +1,27 @@
+{
+  "skill_name": "fact-checker",
+  "evals": [
+    {
+      "id": "verify-version-sensitive-claims",
+      "prompt": "Check these claims before publish: Swift Testing can replace XCTest in every production suite right now; Context7 always contains the newest official docs; Jekyll remote Unsplash images automatically work for all OG and Twitter cards without extra checks.",
+      "expected_output": "A claim-by-claim review that separates verified, unsupported, and stale statements, names primary sources, and recommends wording changes where needed.",
+      "assertions": [
+        "Evaluates each claim individually",
+        "Names primary or official sources",
+        "Separates verified conclusions from unsupported claims",
+        "Suggests qualification or wording changes where needed"
+      ]
+    },
+    {
+      "id": "preservation-first-advisory-check",
+      "prompt": "This historical post includes old tool references. Check whether the claims are still accurate, but treat any proposed text changes as advisory because the source prose is protected.",
+      "expected_output": "An accuracy review that surfaces stale or ambiguous claims, cites sources, and keeps rewrite suggestions explicitly advisory because the text is preservation-first.",
+      "assertions": [
+        "Keeps the result advisory for preservation-first content",
+        "Flags stale or ambiguous claims clearly",
+        "Uses source-backed reasoning instead of memory",
+        "Does not drift into broad prose rewriting"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/historical-post-editor/SKILL.md
+++ b/.agents/skills/historical-post-editor/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: historical-post-editor
-description: Safely improve styling, media, and SEO for an existing published post while preserving its title, description, publish date, filename date, and prose body by default.
+description: "Use this skill when the user wants preservation-safe improvements to a tracked published post's styling, media, or SEO while keeping its historical text and dates intact by default. Apply it to existing repo posts that need maintenance or presentation fixes, not Medium migration, net-new drafting, or broad rewrites."
 ---
 
 # Historical Post Editor
 
 Use this skill when editing an existing tracked post without changing its historical text or dates.
+
+## Routing Boundaries
+
+- Use it for tracked published posts that need safe presentation, metadata, or rendering fixes.
+- Do not use it for Medium-origin imports or conversions. Route those to `medium-porter`.
+- Do not use it for writing new article bodies or broad rewrites. Route those to `technical-post-drafter`.
+- Do not use it for general voice polish of existing prose. Route that to `sh-humanizer`.
+- Do not use it for ordinary draft creation or publish packaging. Route that to `jekyll-post-publisher`.
 
 ## Workflow
 
@@ -16,7 +24,16 @@ Use this skill when editing an existing tracked post without changing its histor
    the task.
 4. Snapshot the protected fields before editing.
 5. Make only preservation-safe changes unless the user explicitly asks for text or date edits.
-6. Run `scripts/assert-protected-post-fields.sh` before calling the work done.
+6. Use `scripts/assert-protected-post-fields.sh <before-path> <after-path>` before calling the
+   work done.
+
+## Available Scripts
+
+- `scripts/assert-protected-post-fields.sh --help` shows supported flags and examples.
+- `scripts/assert-protected-post-fields.sh <before-path> <after-path>` validates the protected
+  title, description, publish date, filename date, and prose body text.
+- `scripts/assert-protected-post-fields.sh --format jsonl <before-path> <after-path>` emits one
+  structured result with the protected-field checks.
 
 ## Output Expectations
 

--- a/.agents/skills/historical-post-editor/agents/openai.yaml
+++ b/.agents/skills/historical-post-editor/agents/openai.yaml
@@ -1,4 +1,7 @@
 interface:
   display_name: "Historical Post Editor"
-  short_description: "Improve existing posts without changing their historical text or dates"
+  short_description: "Improve published posts without altering historical text"
   default_prompt: "Use $historical-post-editor to update this published post's media, styling, or SEO while preserving its title, description, date, and prose."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/historical-post-editor/evals/eval_queries.json
+++ b/.agents/skills/historical-post-editor/evals/eval_queries.json
@@ -1,0 +1,31 @@
+{
+  "skill_name": "historical-post-editor",
+  "train": {
+    "should_trigger": [
+      "Safely update this published post's figure markup and SEO without changing the prose or date.",
+      "This tracked post needs media and metadata cleanup, but the historical text must stay intact.",
+      "Fix the rendering and social metadata on this published article without rewriting the body.",
+      "Make preservation-safe presentation edits to this existing repo post."
+    ],
+    "should_not_trigger": [
+      "I copied this Medium article into the repo. Convert it into site-native Jekyll content.",
+      "Turn this outline into a full technical article body.",
+      "Rewrite this section so it sounds more like me and less like AI.",
+      "Add front matter, validate this draft, and publish it into _posts_."
+    ]
+  },
+  "validation": {
+    "should_trigger": [
+      "Refresh the figure markup in this tracked post but keep the title, description, dates, and prose body unchanged.",
+      "Apply safe SEO maintenance to this published article without historical drift.",
+      "This existing post has broken media presentation. Fix it without touching the prose.",
+      "Do a preservation-first cleanup on this published post's rendering and metadata."
+    ],
+    "should_not_trigger": [
+      "Port this Medium draft into the blog repository.",
+      "Research the unsupported claims in this article before publish.",
+      "Give me five blog ideas about platform contracts and debugging.",
+      "I have an outline and notes. Draft the article body."
+    ]
+  }
+}

--- a/.agents/skills/historical-post-editor/evals/evals.json
+++ b/.agents/skills/historical-post-editor/evals/evals.json
@@ -1,0 +1,33 @@
+{
+  "skill_name": "historical-post-editor",
+  "evals": [
+    {
+      "id": "preservation-safe-figure-and-seo-fix",
+      "prompt": "Update the published post in evals/files/2024-08-15-metrics-hide-failure.md so the media uses the site's figure markup and the post gets safe SEO maintenance. Preserve the title, description, date, filename date, and prose body text.",
+      "files": [
+        "evals/files/2024-08-15-metrics-hide-failure.md"
+      ],
+      "expected_output": "A preservation-safe update that limits changes to allowed maintenance areas and validates the protected fields before completion.",
+      "assertions": [
+        "Preserves title, description, front matter date, and filename date",
+        "Preserves prose body text",
+        "Converts article media to the figure.post-figure and figcaption pattern or an equivalent repo-standard form",
+        "Uses scripts/assert-protected-post-fields.sh before calling the work done"
+      ]
+    },
+    {
+      "id": "tracked-post-rendering-maintenance",
+      "prompt": "Make rendering-safe media and metadata fixes to evals/files/2024-08-15-metrics-hide-failure.md without broad rewrites. Treat prose edits as out of scope unless they are explicitly approved.",
+      "files": [
+        "evals/files/2024-08-15-metrics-hide-failure.md"
+      ],
+      "expected_output": "A maintenance-focused result that keeps the historical text intact and limits the work to presentation, media, or metadata fixes.",
+      "assertions": [
+        "Keeps the work scoped to maintenance-safe changes",
+        "Avoids large rewrites or migration behavior",
+        "Calls out preservation boundaries explicitly",
+        "Leaves the result ready for rendering review"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/historical-post-editor/evals/files/2024-08-15-metrics-hide-failure.md
+++ b/.agents/skills/historical-post-editor/evals/files/2024-08-15-metrics-hide-failure.md
@@ -1,0 +1,25 @@
+---
+title: "When Metrics Hide The Real Failure"
+description: "A published post fixture for preservation-safe editorial skill evals."
+date: 2024-08-15 09:00:00 -0400
+last_modified_at: 2024-08-15 09:00:00 -0400
+categories:
+  - Mobile Engineering
+tags:
+  - Debugging
+  - Systems Thinking
+image: "https://images.unsplash.com/photo-1516321318423-f06f85e504b3"
+image_alt: "Diagnostic charts on a laptop beside a phone"
+image_source: "unsplash"
+fact_check_status: "complete"
+permalink: /when-metrics-hide-the-real-failure/
+---
+
+Teams usually notice the dashboard before they notice the broken assumption.
+
+![A chart on a laptop screen](https://example.com/chart.jpg)
+
+The problem is not that the metric exists. The problem is that the metric starts acting like the
+system.
+
+Once that happens, the team starts managing the proxy instead of the failure mode.

--- a/.agents/skills/historical-post-editor/references/preservation-rules.md
+++ b/.agents/skills/historical-post-editor/references/preservation-rules.md
@@ -20,5 +20,8 @@ Allowed changes:
 
 Before finishing:
 
-- compare the before and after versions with `scripts/assert-protected-post-fields.sh`
+- compare the before and after versions with
+  `scripts/assert-protected-post-fields.sh <before-path> <after-path>`
+- use `scripts/assert-protected-post-fields.sh --format jsonl <before-path> <after-path>` when you
+  need structured check output
 - preview the affected post if rendering changed

--- a/.agents/skills/historical-post-editor/scripts/assert-protected-post-fields.sh
+++ b/.agents/skills/historical-post-editor/scripts/assert-protected-post-fields.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+format="text"
+
+usage() {
+  cat <<'EOF'
+Usage: assert-protected-post-fields.sh [--help] [--format text|jsonl] <before-path> <after-path>
+
+Validate preservation-safe edits for tracked published posts.
+
+Checks:
+  - front matter title is unchanged
+  - front matter description is unchanged
+  - front matter date is unchanged
+  - _posts/YYYY-MM-DD filename date is unchanged when present
+  - prose body text is unchanged after normalizing image and figure markup
+
+Options:
+  --help                Show this help and exit.
+  --format FORMAT       Output format: text (default) or jsonl.
+
+Examples:
+  scripts/assert-protected-post-fields.sh before.md after.md
+  scripts/assert-protected-post-fields.sh --format jsonl _before/post.md _after/post.md
+EOF
+}
+
+paths=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      usage
+      exit 0
+      ;;
+    --format)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "error: --format requires a value" >&2
+        exit 1
+      fi
+      format="$1"
+      case "$format" in
+        text|jsonl) ;;
+        *)
+          echo "error: --format must be 'text' or 'jsonl'" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    --*)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      paths+=("$1")
+      ;;
+  esac
+  shift
+done
+
+if [[ ${#paths[@]} -ne 2 ]]; then
+  usage >&2
+  exit 1
+fi
+
+ruby - "$format" "${paths[0]}" "${paths[1]}" <<'RUBY'
+require "date"
+require "json"
+require "yaml"
+
+format = ARGV.shift
+before_path = ARGV.shift
+after_path = ARGV.shift
+
+def parse_post(path)
+  abort("error: file not found: #{path}") unless File.file?(path)
+
+  content = File.read(path)
+  match = content.match(/\A---\s*\n(.*?)\n---\s*\n/m)
+  abort("error: missing YAML front matter in #{path}") unless match
+
+  front_matter = YAML.safe_load(match[1], permitted_classes: [Time, Date], aliases: true) || {}
+  body = content[match[0].length..] || ""
+
+  {
+    path: path,
+    basename: File.basename(path),
+    title: front_matter["title"].to_s,
+    description: front_matter["description"].to_s,
+    date: front_matter["date"].to_s,
+    filename_date: File.basename(path)[/\A\d{4}-\d{2}-\d{2}/].to_s,
+    prose_fingerprint: normalize_prose(body)
+  }
+end
+
+def normalize_prose(body)
+  normalized = body.dup
+  normalized.gsub!(%r{<figure\b.*?</figure>}m, "\n")
+  normalized.gsub!(%r{!\[[^\]]*\]\([^)]+\)}, "")
+  normalized.gsub!(%r{^\s*<img\b[^>]*>\s*$}i, "")
+  normalized.gsub!(%r{^\s*<figcaption\b.*?</figcaption>\s*$}im, "")
+  normalized.gsub!(/[ \t]+/, " ")
+  normalized.gsub!(/\n{3,}/, "\n\n")
+  normalized.lines.map(&:rstrip).join("\n").strip
+end
+
+before = parse_post(before_path)
+after = parse_post(after_path)
+
+checks = [
+  {
+    name: "title",
+    expected: before[:title],
+    actual: after[:title],
+    passed: before[:title] == after[:title]
+  },
+  {
+    name: "description",
+    expected: before[:description],
+    actual: after[:description],
+    passed: before[:description] == after[:description]
+  },
+  {
+    name: "date",
+    expected: before[:date],
+    actual: after[:date],
+    passed: before[:date] == after[:date]
+  },
+  {
+    name: "filename_date",
+    expected: before[:filename_date],
+    actual: after[:filename_date],
+    passed: before[:filename_date] == after[:filename_date]
+  },
+  {
+    name: "prose_body",
+    expected: before[:prose_fingerprint],
+    actual: after[:prose_fingerprint],
+    passed: before[:prose_fingerprint] == after[:prose_fingerprint]
+  }
+]
+
+failed = checks.reject { |check| check[:passed] }
+
+if format == "jsonl"
+  puts JSON.generate(
+    before_path: before_path,
+    after_path: after_path,
+    status: failed.empty? ? "validated" : "failed",
+    checks: checks
+  )
+else
+  if failed.empty?
+    puts "validated: #{after_path}"
+  else
+    failed.each do |check|
+      warn(
+        "error: protected field changed for #{check[:name]} in #{after_path}\n" \
+        "expected: #{check[:expected].inspect}\n" \
+        "actual: #{check[:actual].inspect}"
+      )
+    end
+    exit 1
+  end
+end
+
+exit 1 unless failed.empty?
+RUBY

--- a/.agents/skills/jekyll-post-publisher/SKILL.md
+++ b/.agents/skills/jekyll-post-publisher/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: jekyll-post-publisher
-description: Create draft files, normalize front matter, validate, and publish posts for this Jekyll blog. Use when opening a private local draft file, editing metadata, adding prompt-supplied Unsplash cover images, running publish QA, or promoting content from _drafts to _posts.
+description: "Use this skill when the user needs repo-specific post packaging: front matter, draft creation, validation, publish QA, or promotion from _drafts to _posts. Apply it to metadata normalization and publication workflow after the body largely exists, not to ideation, full article drafting, source verification, or voice rewrites."
 ---
 
 # Jekyll Post Publisher
 
 Use this skill for repo-specific blog work.
+
+## Routing Boundaries
+
+- Use it for file creation, front matter normalization, validation, publish QA, and promotion into tracked posts.
+- Do not use it for topic ideation or editorial backlog work. Route that to `content-brainstormer`.
+- Do not use it for writing or restructuring the main article body. Route that to `technical-post-drafter`.
+- Do not use it for claim verification or documentation lookup. Route that to `fact-checker`.
+- Do not use it for voice rewrites of otherwise solid prose. Route that to `sh-humanizer`.
 
 ## When To Use
 
@@ -44,6 +52,12 @@ Use this skill for repo-specific blog work.
 8. Use `scripts/validate-post.sh <path>` before calling a post ready.
 9. Use `make validate-draft`, `make qa-publish`, and `make publish-draft` as the repo-level
    workflow for drafts.
+
+## Available Scripts
+
+- `scripts/validate-post.sh --help` shows supported flags and examples.
+- `scripts/validate-post.sh <path>` validates a draft or tracked post in text mode.
+- `scripts/validate-post.sh --format jsonl <path>` emits one structured result per validated file.
 
 ## Output Expectations
 

--- a/.agents/skills/jekyll-post-publisher/agents/openai.yaml
+++ b/.agents/skills/jekyll-post-publisher/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Jekyll Post Publisher"
   short_description: "Manage Jekyll post metadata and publish workflow"
   default_prompt: "Use $jekyll-post-publisher to package, validate, or publish a blog post for this repository."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/jekyll-post-publisher/evals/evals.json
+++ b/.agents/skills/jekyll-post-publisher/evals/evals.json
@@ -1,0 +1,34 @@
+{
+  "skill_name": "jekyll-post-publisher",
+  "evals": [
+    {
+      "id": "package-body-only-draft",
+      "prompt": "Turn evals/files/draft-body-only.md into a private draft with site-ready front matter, explicit validation status, and the right next publication step. Keep the work focused on packaging, not body rewriting.",
+      "files": [
+        "evals/files/draft-body-only.md"
+      ],
+      "expected_output": "A repo-ready private draft with complete front matter, a validation step, and a clear next command or workflow handoff.",
+      "assertions": [
+        "Adds YAML front matter or an equivalent metadata block",
+        "Includes title, description, permalink, categories, tags, and last_modified_at",
+        "Includes image metadata and fact_check_status when packaging for publish readiness",
+        "References validation or publish workflow steps such as scripts/validate-post.sh or make validate-draft",
+        "Avoids large article-body rewrites"
+      ]
+    },
+    {
+      "id": "finish-metadata-for-publish-ready-draft",
+      "prompt": "Complete the packaging work for evals/files/draft-metadata-incomplete.md so it is ready for publish QA. Normalize the front matter, validate it, and state the next repo workflow step.",
+      "files": [
+        "evals/files/draft-metadata-incomplete.md"
+      ],
+      "expected_output": "A publish-ready packaging result that normalizes metadata, validates the draft, and clearly states the next repo-local workflow step.",
+      "assertions": [
+        "Normalizes front matter fields required by this repo",
+        "Preserves the focus on metadata, validation, and publication workflow",
+        "States validation status explicitly",
+        "Names the next repo-local command or workflow step"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/jekyll-post-publisher/evals/files/draft-body-only.md
+++ b/.agents/skills/jekyll-post-publisher/evals/files/draft-body-only.md
@@ -1,0 +1,7 @@
+Mobile teams often treat debugging like a tooling problem because tools are visible and contracts
+are not.
+
+That framing works right up until the system starts failing in places where the tooling is
+technically correct but strategically useless.
+
+The real issue is usually that the team never made the runtime contract explicit.

--- a/.agents/skills/jekyll-post-publisher/evals/files/draft-metadata-incomplete.md
+++ b/.agents/skills/jekyll-post-publisher/evals/files/draft-metadata-incomplete.md
@@ -1,0 +1,16 @@
+---
+title: "When Platform Leverage Gets Treated Like Implementation Detail"
+description: "A draft fixture for packaging and validation evals."
+permalink: /when-platform-leverage-gets-treated-like-implementation-detail/
+categories:
+  - Mobile Engineering
+tags:
+  - Architecture
+  - Leadership
+last_modified_at: 2026-03-14 10:00:00 -0400
+---
+
+Platform power is easy to dismiss when the organization talks about it as implementation detail.
+
+The consequence is predictable. Teams lose leverage first, then they lose the language to explain
+why the leverage mattered.

--- a/.agents/skills/jekyll-post-publisher/scripts/validate-post.sh
+++ b/.agents/skills/jekyll-post-publisher/scripts/validate-post.sh
@@ -2,17 +2,77 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+format="text"
+strict_metadata="${STRICT_POST_METADATA:-0}"
 
-if [[ $# -lt 1 ]]; then
-  echo "usage: $0 <post-or-draft-path> [more-paths...]" >&2
+usage() {
+  cat <<'EOF'
+Usage: validate-post.sh [--help] [--format text|jsonl] [--strict] <post-or-draft-path> [more-paths...]
+
+Validate repo-specific front matter and path conventions for tracked posts or private drafts.
+
+Options:
+  --help                Show this help and exit.
+  --format FORMAT       Output format: text (default) or jsonl.
+  --strict              Require image and fact-check metadata even for drafts.
+
+Examples:
+  scripts/validate-post.sh _drafts/my-post.md
+  scripts/validate-post.sh --strict _posts/2026-03-14-my-post.md
+  scripts/validate-post.sh --format jsonl _drafts/my-post.md
+EOF
+}
+
+paths=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      usage
+      exit 0
+      ;;
+    --format)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "error: --format requires a value" >&2
+        exit 1
+      fi
+      format="$1"
+      case "$format" in
+        text|jsonl) ;;
+        *)
+          echo "error: --format must be 'text' or 'jsonl'" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    --strict)
+      strict_metadata="1"
+      ;;
+    --*)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      paths+=("$1")
+      ;;
+  esac
+  shift
+done
+
+if [[ ${#paths[@]} -lt 1 ]]; then
+  usage >&2
   exit 1
 fi
 
-ruby - "$repo_root" "$@" <<'RUBY'
+ruby - "$repo_root" "$format" "$strict_metadata" "${paths[@]}" <<'RUBY'
 require "date"
+require "json"
 require "yaml"
 
 repo_root = ARGV.shift
+format = ARGV.shift
+strict_metadata = ARGV.shift == "1"
 
 ARGV.each do |path|
   abort("error: file not found: #{path}") unless File.file?(path)
@@ -24,7 +84,7 @@ ARGV.each do |path|
   data = YAML.safe_load(match[1], permitted_classes: [Time, Date], aliases: true) || {}
   required = %w[title description permalink categories tags last_modified_at]
   strict_required = %w[image image_alt image_source fact_check_status]
-  required.concat(strict_required) if ENV.fetch("STRICT_POST_METADATA", "0") == "1"
+  required.concat(strict_required) if strict_metadata
   missing = required.reject do |key|
     value = data[key]
     !(value.nil? || (value.respond_to?(:empty?) && value.empty?))
@@ -79,6 +139,10 @@ ARGV.each do |path|
     abort("error: published posts must include date in #{path}") if data["date"].nil?
   end
 
-  puts "validated: #{path}"
+  if format == "jsonl"
+    puts JSON.generate({ path: path, status: "validated" })
+  else
+    puts "validated: #{path}"
+  end
 end
 RUBY

--- a/.agents/skills/medium-porter/SKILL.md
+++ b/.agents/skills/medium-porter/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: medium-porter
-description: Migrate Medium posts into this Jekyll site with polish. Use when porting legacy articles, normalizing metadata, improving structure, or converting a Medium-style post into a site-native article while preserving voice.
+description: "Use this skill when the user is bringing Medium-origin content into this Jekyll site and needs migration, normalization, or a controlled site-native adaptation. Apply it to imported Medium drafts or posts, not tracked-post maintenance, net-new article drafting, or ordinary publish packaging."
 ---
 
 # Medium Porter
 
 Use this skill when importing or cleaning up Medium-origin content.
+
+## Routing Boundaries
+
+- Use it for Medium-source migration, cleanup, metadata normalization, and controlled adaptation into the site.
+- Do not use it for editing an already tracked historical post. Route that to `historical-post-editor`.
+- Do not use it for net-new article drafting from notes or outlines. Route that to `technical-post-drafter`.
+- Do not use it for pure voice polish on prose that is already site-native. Route that to `sh-humanizer`.
+- Do not use it for ordinary draft packaging or publication once the migration body is ready. Route that to `jekyll-post-publisher`.
 
 ## Workflow
 

--- a/.agents/skills/medium-porter/agents/openai.yaml
+++ b/.agents/skills/medium-porter/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Medium Porter"
   short_description: "Port Medium posts into site-native Jekyll content"
   default_prompt: "Use $medium-porter to migrate this Medium post into the blog repository."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/medium-porter/evals/eval_queries.json
+++ b/.agents/skills/medium-porter/evals/eval_queries.json
@@ -1,0 +1,31 @@
+{
+  "skill_name": "medium-porter",
+  "train": {
+    "should_trigger": [
+      "I copied this Medium article into the repo. Convert it into site-native Jekyll content.",
+      "Port this Medium post into my blog while preserving its original date and body.",
+      "Normalize this imported Medium draft so it matches the site's Jekyll conventions.",
+      "Take this Medium-origin article and prepare a faithful port for the repo."
+    ],
+    "should_not_trigger": [
+      "Safely update this published post's figure markup and SEO without changing the prose.",
+      "Add front matter and publish this draft into _posts_.",
+      "Turn this outline into a full technical article body.",
+      "Rewrite this section so it sounds more like me and less like AI."
+    ]
+  },
+  "validation": {
+    "should_trigger": [
+      "Migrate this Medium article into the site and keep the historical text intact unless I ask for a rewrite.",
+      "I imported a Medium draft. Convert it into the repo's post format.",
+      "Prepare a site-native version of this Medium post with normalized metadata and media handling.",
+      "Handle this Medium-to-Jekyll migration without turning it into a net-new article draft."
+    ],
+    "should_not_trigger": [
+      "Research the unsupported claims in this draft before publish.",
+      "Give me five insight-led angles for a post about release engineering.",
+      "Update this tracked post's rendering while preserving the historical text.",
+      "I have notes and a thesis. Draft the actual article body."
+    ]
+  }
+}

--- a/.agents/skills/medium-porter/evals/evals.json
+++ b/.agents/skills/medium-porter/evals/evals.json
@@ -1,0 +1,33 @@
+{
+  "skill_name": "medium-porter",
+  "evals": [
+    {
+      "id": "faithful-medium-port",
+      "prompt": "Convert evals/files/medium-runtime-contract.md into site-native Jekyll content. Default to a faithful port that preserves the title, source date, prose body, and media order while normalizing metadata.",
+      "files": [
+        "evals/files/medium-runtime-contract.md"
+      ],
+      "expected_output": "A faithful Medium-to-Jekyll port with normalized site metadata and preserved protected source fields.",
+      "assertions": [
+        "Preserves the original title and source date in faithful-port mode",
+        "Preserves prose body and media order by default",
+        "Adds site-native front matter or equivalent metadata packaging",
+        "Leaves any time-sensitive claim review as follow-up fact-check work unless the user asks for content edits"
+      ]
+    },
+    {
+      "id": "site-native-adaptation-boundary",
+      "prompt": "Review evals/files/medium-runtime-contract.md for a site-native adaptation. Keep the migration workflow in scope, but route any large rewrite of the article body to technical-post-drafter.",
+      "files": [
+        "evals/files/medium-runtime-contract.md"
+      ],
+      "expected_output": "A migration-focused result that distinguishes faithful port work from article-body rewriting and uses the correct handoff when adaptation crosses into drafting.",
+      "assertions": [
+        "Keeps migration and normalization in scope",
+        "Avoids broad rewrites unless explicitly requested",
+        "Routes substantial body rewriting to technical-post-drafter",
+        "Stays distinct from historical-post-editor and jekyll-post-publisher behavior"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/medium-porter/evals/files/medium-runtime-contract.md
+++ b/.agents/skills/medium-porter/evals/files/medium-runtime-contract.md
@@ -1,0 +1,14 @@
+# The Runtime Contract Nobody Writes Down
+
+Originally published on Medium, June 10, 2023.
+
+Most teams talk about architecture as if the diagram were the contract. In practice, the runtime
+contract is whatever the system punishes when you violate it.
+
+When that contract is implicit, teams mistake breakage for bad luck. It is usually a design
+failure that nobody named early enough.
+
+![Architecture sketch](https://example.com/runtime-contract.jpg)
+
+The article should keep its body and media order in a faithful port unless the user explicitly asks
+for a site-native rewrite.

--- a/.agents/skills/technical-post-drafter/SKILL.md
+++ b/.agents/skills/technical-post-drafter/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: technical-post-drafter
-description: Draft and reshape technical blog posts for this site. Use when turning a topic, outline, source notes, or rough draft into a structured article with a strong hook, clear section flow, concrete examples, and intact author voice before fact checking and publish QA.
+description: "Use this skill when the user needs to write or substantially reshape the body of a technical post for this site from a topic, outline, notes, transcript, or rough draft. Apply it to net-new drafting and major restructures before fact checking and publish QA, not ideation, pure voice polish, source verification, or metadata packaging."
 ---
 
 # Technical Post Drafter
 
 Use this skill when the article body needs to be written or substantially reworked.
+
+## Routing Boundaries
+
+- Use it when the body is missing, thin, out of order, or structurally weak.
+- Do not use it for choosing topics or backlog direction. Route that to `content-brainstormer`.
+- Do not use it for pure voice polish on otherwise solid prose. Route that to `sh-humanizer`.
+- Do not use it when the main job is verifying claims or citing sources. Route that to `fact-checker`.
+- Do not use it for metadata, validation, or publish workflow. Route that to `jekyll-post-publisher`.
 
 ## When To Use
 
@@ -25,12 +33,13 @@ Use this skill when the article body needs to be written or substantially rework
 
 ## Workflow
 
-1. Read `references/article-structure.md` for section sequencing and pacing.
-2. Read `references/drafting-rules.md` for voice, example, and claim-marking rules.
-3. If the input is only an idea or hook, hand off to `content-brainstormer` first.
-4. Draft or restructure the article body before metadata polishing.
-5. Send technical claims to `fact-checker` before calling the draft publish-ready.
-6. Hand the checked draft to `jekyll-post-publisher` for front matter, validation, and publication.
+1. Read `../../../.codex/docs/editorial-voice-profile.md`.
+2. Read `references/article-structure.md` for section sequencing and pacing.
+3. Read `references/drafting-rules.md` for voice, example, and claim-marking rules.
+4. If the input is only an idea or hook, hand off to `content-brainstormer` first.
+5. Draft or restructure the article body before metadata polishing.
+6. Send technical claims to `fact-checker` before calling the draft publish-ready.
+7. Hand the checked draft to `jekyll-post-publisher` for front matter, validation, and publication.
 
 ## Output Expectations
 
@@ -49,6 +58,7 @@ Use this skill when the article body needs to be written or substantially rework
 ## Rules
 
 - Preserve the author's judgment and voice; do not flatten it into generic tutorial prose.
+- Default to `problem -> mechanism -> consequence` before drifting into advice or process.
 - Prefer concrete systems examples over abstract claims.
 - Mark uncertain or source-dependent claims so `fact-checker` can verify them.
 - Avoid publish metadata work unless the user asks for file creation or packaging.

--- a/.agents/skills/technical-post-drafter/agents/openai.yaml
+++ b/.agents/skills/technical-post-drafter/agents/openai.yaml
@@ -4,4 +4,4 @@ interface:
   default_prompt: "Use $technical-post-drafter to turn this outline, notes, or rough draft into a strong technical article body."
 
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/.agents/skills/technical-post-drafter/evals/eval_queries.json
+++ b/.agents/skills/technical-post-drafter/evals/eval_queries.json
@@ -1,0 +1,31 @@
+{
+  "skill_name": "technical-post-drafter",
+  "train": {
+    "should_trigger": [
+      "Turn this outline into a full technical article body with stronger section flow.",
+      "Expand these notes into a blog post draft about mobile debugging and system boundaries.",
+      "This rough draft is thin and repetitive. Rewrite the body so the argument actually lands.",
+      "Draft an article from these notes about platform leverage being treated like implementation detail."
+    ],
+    "should_not_trigger": [
+      "Give me five experience-driven blog ideas about mobile incidents.",
+      "Verify whether these library and API claims are still accurate before publish.",
+      "Rewrite this finished section so it sounds more like me and less like AI.",
+      "Add front matter, validate this draft, and publish it into _posts_."
+    ]
+  },
+  "validation": {
+    "should_trigger": [
+      "Restructure this article body so each section has a clearer job and payoff.",
+      "Take this outline and write the actual post, including a stronger hook and ending.",
+      "I have a transcript and rough notes. Turn them into a cohesive article body.",
+      "Sharpen the explanations and examples in this draft without turning it into a tutorial."
+    ],
+    "should_not_trigger": [
+      "I copied this Medium article into the repo. Convert it into site-native Jekyll content.",
+      "I have an outline and three sources. Help me research gaps before I keep writing.",
+      "Safely update this published post's media markup without changing the prose.",
+      "What should I write next if I want to sharpen my point of view in mobile architecture?"
+    ]
+  }
+}

--- a/.agents/skills/technical-post-drafter/evals/evals.json
+++ b/.agents/skills/technical-post-drafter/evals/evals.json
@@ -1,0 +1,32 @@
+{
+  "skill_name": "technical-post-drafter",
+  "evals": [
+    {
+      "id": "outline-to-full-article-body",
+      "prompt": "Turn this outline into a full article body for experienced mobile engineers: Hook about teams blaming tooling instead of contracts; H2 on the mistaken assumption; H2 on the mechanism inside the system boundary; H2 on the organizational consequence; close with a blunt takeaway. Include concrete examples and mark source-dependent claims.",
+      "expected_output": "A full article body with an opening observation or tension, explicit mechanism and consequence, concrete examples, marked source-dependent claims, and a blunt takeaway or explicit next step.",
+      "assertions": [
+        "Includes a clear opening observation or tension",
+        "Uses section headings or an equivalent section structure",
+        "Includes an explanation of mechanism",
+        "Includes a technical, organizational, or strategic consequence",
+        "Adds concrete systems examples or failure modes",
+        "Marks source-dependent or uncertain claims",
+        "Avoids role-title self-reference as a source of authority"
+      ]
+    },
+    {
+      "id": "restructure-thin-rough-draft",
+      "prompt": "This rough draft has the right idea but the sections are repetitive and out of order. Restructure it into a stronger article body about why platform leverage gets treated like implementation detail on mobile teams. Keep the voice judgment-forward, not tutorial-like.",
+      "expected_output": "A materially stronger article body that clarifies the throughline, sharpens section order, makes mechanism and consequence visible, and preserves a judgment-forward voice without drifting into metadata or packaging work.",
+      "assertions": [
+        "Improves section order or flow",
+        "Makes mechanism or causal logic clearer",
+        "Makes consequence or implication clearer",
+        "Keeps the response focused on body drafting rather than publication workflow",
+        "Includes at least one concrete tradeoff, failure mode, or system consequence",
+        "Avoids role-title self-reference as a source of authority"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/technical-post-drafter/references/article-structure.md
+++ b/.agents/skills/technical-post-drafter/references/article-structure.md
@@ -4,29 +4,32 @@ Use these patterns when drafting or restructuring a post for this site.
 
 ## Default Shape
 
-1. Hook: open on tension, failure, or a surprising observation in 1 to 3 short paragraphs.
-2. Problem frame: explain why the reader should care now.
-3. Main sections: use 2 to 4 H2s, each with one core idea, one concrete example, and one takeaway.
-4. Synthesis: connect the sections back to broader engineering judgment.
-5. Close: end with a practical takeaway, caution, or decision heuristic.
+1. Opening observation or tension: open on a real failure, pressure point, or mistaken assumption in 1 to 3 short paragraphs.
+2. Mechanism: explain why the situation happens beneath the visible symptom.
+3. Consequence: show the technical, organizational, or strategic cost of that mechanism.
+4. Broader implication: connect the specific case back to engineering judgment, structure, or team behavior.
+5. Blunt takeaway: end with a heuristic, stance, or reframing that the reader can carry forward.
 
 ## Section Tests
 
 - the first sentence tells the reader why the section exists
+- the section makes the causal link visible instead of only naming the problem
 - the section ends with a takeaway or transition
 - examples do real explanatory work instead of decoration
 - subtle concepts get a contrast case, failure mode, or tradeoff
 
 ## Common Shapes
 
-- debugging or incident post: symptom, false assumption, investigation, fix, transferable lesson
-- architecture post: tension, constraints, options, chosen shape, implications
-- AI or tools post: user problem, system limit, practical pattern, caveats, adoption advice
-- leadership post: observed failure mode, mechanism, intervention, caution, repeatable heuristic
+- debugging or incident post: symptom, false assumption, underlying mechanism, consequence, transferable lesson
+- architecture post: pressure, constraints, structural choice, consequence, decision rule
+- AI or tools post: visible promise, hidden system limit, mechanism, consequence, adoption heuristic
+- leadership post: observed failure mode, organizational mechanism, consequence, intervention, caution
 
 ## Anti-Patterns
 
+- tutorial sequencing that replaces the actual argument
 - tutorial openings that bury the real tension
 - long context dumps before the thesis
 - stacked abstractions with no story or example
 - conclusions that only restate headings
+- sections that explain what to do without explaining why the pattern keeps happening

--- a/.agents/skills/technical-post-drafter/references/drafting-rules.md
+++ b/.agents/skills/technical-post-drafter/references/drafting-rules.md
@@ -2,22 +2,32 @@
 
 ## Voice
 
-- Write like a principal mobile engineer explaining a pattern after seeing it fail in practice across systems, teams, or platform boundaries.
-- Prefer strong nouns and verbs over hype.
-- Keep confidence proportional to evidence.
-- Use first person only when lived experience adds credibility.
-- Favor org-level judgment, platform strategy, and architectural consequence over narrow implementation trivia.
+- Write like an experienced engineer thinking out loud about real systems, teams, and boundaries.
+- Use plain language, short to medium sentences, and jargon only when it clarifies.
+- Let observation and reasoning carry authority. Do not lean on role titles or credential signaling.
+- Be direct when a practice, assumption, or framing is flawed.
+- Use first person only when lived experience sharpens the point.
+- Dense paragraphs are fine if every sentence adds signal.
+
+## Default Movement
+
+- Start from a real problem, observation, or tension.
+- Explain the mechanism before turning to advice.
+- Show the consequence: technical, organizational, or strategic.
+- Add the broader implication when it helps the reader update their mental model.
+- Prefer insight over tutorial unless the prompt explicitly asks for step-by-step instruction.
 
 ## Hook And Flow
 
 - Open on tension, consequence, or a mistaken assumption.
 - Let each section answer a question created by the previous section.
+- Keep headings claim-bearing and crisp.
 - Trim throat-clearing and duplicated summaries.
 
 ## Examples
 
 - Use one concrete example per major section when possible.
-- Prefer system behavior, failure modes, or tradeoffs over toy examples.
+- Prefer system behavior, failure modes, repeated team patterns, or tradeoffs over toy examples.
 - If a detail is illustrative but unverified, flag it for fact checking.
 
 ## Claim Marking
@@ -28,5 +38,6 @@
 
 ## Finish Line
 
-- Leave the reader with a heuristic, decision rule, or changed mental model.
+- End with a blunt takeaway, decision rule, or changed mental model.
+- The last lines should sharpen the point, not politely summarize it.
 - Identify the next workflow step: `fact-checker` or `jekyll-post-publisher`.

--- a/.codex/docs/editorial-policy.md
+++ b/.codex/docs/editorial-policy.md
@@ -1,16 +1,17 @@
 # Editorial Policy
 
-## Positioning
+## Editorial Focus
 
-This site is an authority-building publication for:
+This site is an experience-driven engineering publication focused on:
 
 - mobile architecture
 - debugging and failure analysis
 - systems thinking
 - AI engineering
-- principal mobile engineering leadership
+- mobile engineering leadership
 
-The writing should strengthen that positioning rather than chase generic traffic.
+The writing should strengthen that focus through insight, judgment, and consequence rather than
+chase generic traffic.
 
 ## Drafting Model
 
@@ -52,15 +53,16 @@ Every publish-ready post needs:
 - Use Context7 when the official docs are available there and the precise behavior matters.
 - Rewrite or remove claims that cannot be supported cleanly.
 
-## Authority-First Topic Selection
+## Insight-Led Topic Selection
 
 Prioritize ideas that:
 
-- demonstrate original experience
+- demonstrate repeated field experience
 - reveal systems thinking
-- show principal judgment in architecture, platform strategy, or cross-team technical direction
-- connect real engineering tradeoffs to practical lessons
-- compound reputation in the site's core domains
+- show strong engineering judgment in architecture, platform strategy, or cross-team technical
+  direction
+- connect real engineering tradeoffs to practical consequence
+- deepen the site's point of view in the core domains
 
 ## Publish QA
 

--- a/.codex/docs/editorial-skill-trigger-evals.md
+++ b/.codex/docs/editorial-skill-trigger-evals.md
@@ -1,0 +1,97 @@
+# Editorial Skill Trigger Evals
+
+Use this guide to evaluate implicit routing for the editorial skill set without overloading
+`evals/evals.json`.
+
+## Artifact Split
+
+Use two distinct artifact types:
+
+- `evals/eval_queries.json`
+  Contains routing prompts only. For each implicitly invokable skill, keep fixed `train` and
+  `validation` groups with both `should_trigger` and `should_not_trigger` queries.
+- `evals/evals.json`
+  Contains output-quality checks only. These cases evaluate what the skill produces after routing
+  is already correct.
+
+Current routing artifacts:
+
+- `.agents/skills/content-brainstormer/evals/eval_queries.json`
+- `.agents/skills/technical-post-drafter/evals/eval_queries.json`
+- `.agents/skills/fact-checker/evals/eval_queries.json`
+- `.agents/skills/historical-post-editor/evals/eval_queries.json`
+- `.agents/skills/medium-porter/evals/eval_queries.json`
+- `~/.codex/skills/content-research-writer/evals/eval_queries.json`
+- `~/.codex/skills/sh-humanizer/evals/eval_queries.json`
+
+`jekyll-post-publisher` stays explicit-only in this repo, so it has output-quality evals but no
+implicit-routing query set.
+
+## Run Method
+
+For each routing query:
+
+1. Run it in a fresh thread with no explicit `$skill-name`.
+2. Repeat the same prompt 3 times.
+3. Record whether the intended skill triggers first on each run.
+4. Grade trigger rate separately for `train` and `validation`.
+
+Pass thresholds:
+
+- `should_trigger`: trigger rate must be greater than `0.5`
+- `should_not_trigger`: trigger rate must be less than `0.5`
+
+Do not accept description or policy changes based only on the train set. Compare train and
+validation behavior before keeping a routing update.
+
+## Recommended Workspace
+
+For each evaluated skill, keep a local results workspace with:
+
+- `with_skill/`
+  Explicit `$skill-name` runs for output comparison.
+- `without_skill/`
+  Clean-context runs for implicit routing checks.
+- `outputs/`
+  Captured model outputs for each iteration.
+- `timing.json`
+  Run timing, latency, and invocation metadata.
+- `grading.json`
+  Pass or fail notes, routing collisions, and human review comments.
+- `benchmark.json`
+  A per-iteration summary with aggregate trigger rates for train and validation.
+
+Save three fresh-thread runs per prompt so the trigger rate is meaningful enough to compare.
+
+## Coverage Targets
+
+Target 16 queries per implicitly invokable editorial skill:
+
+- 8 `should_trigger`
+- 8 `should_not_trigger`
+- 4 and 4 in `train`
+- 4 and 4 in `validation`
+
+Bias the negative cases toward near-miss prompts that could plausibly collide:
+
+- ideation vs drafting
+- drafting vs voice rewrite
+- research and revision vs fact checking
+- historical preservation vs Medium migration
+- explicit packaging and publish workflow
+
+## Output-Quality Evals
+
+Use `evals/evals.json` to check output quality after routing:
+
+- include `skill_name`
+- keep `evals` as the case list
+- include `expected_output`
+- include `files` when the case depends on concrete fixtures
+- use assertions only for objective checks such as preserved fields, required sections, explicit
+  next steps, or metadata completeness
+
+Keep voice, usefulness, and boundary quality in human review notes inside `grading.json`.
+
+Use `.codex/docs/editorial-voice-eval-rubric.md` for the manual voice review checklist during those
+notes.

--- a/.codex/docs/editorial-voice-eval-rubric.md
+++ b/.codex/docs/editorial-voice-eval-rubric.md
@@ -1,0 +1,21 @@
+# Editorial Voice Eval Rubric
+
+Use this rubric for human review notes in `grading.json` during output-quality evals.
+
+## Pass Criteria
+
+- Starts from a real observation, tension, or failure instead of generic setup.
+- Makes the mechanism visible, not just the recommendation.
+- Lands on a consequence, implication, or heuristic instead of a soft summary.
+- Uses plain language and direct judgment.
+- Includes a concrete system behavior, tradeoff, or failure mode.
+- Avoids marketing filler, tutorial padding, and credential-signaling authority.
+
+## Recording Notes
+
+Capture short notes for:
+
+- strongest line or section
+- weakest point in the argument shape
+- whether the piece sounds like an engineer thinking out loud
+- whether the ending actually sticks

--- a/.codex/docs/editorial-voice-profile.md
+++ b/.codex/docs/editorial-voice-profile.md
@@ -1,0 +1,46 @@
+# Editorial Voice Profile
+
+Use this as the canonical voice contract for repo-local editorial skills.
+
+## Core Posture
+
+- Write like an experienced engineer thinking out loud about real systems, teams, and tradeoffs.
+- Use plain language first. Jargon is allowed only when it sharpens the point.
+- Sound direct, grounded, and honest. Do not add polish for its own sake.
+- Let observation and reasoning carry authority. Do not lean on role titles or self-promotion.
+- Draw from repeated field experience, not abstract theory.
+
+## Default Argument Shape
+
+- Start with a real observation, tension, or failure mode.
+- Explain the mechanism that makes the problem happen.
+- Show the consequence: technical, organizational, strategic, or cultural.
+- Add the broader implication when it helps the reader update their mental model.
+- End with a blunt takeaway, heuristic, or reframing that sticks.
+
+## What To Lean On
+
+- recurring patterns seen across systems or teams
+- mistaken assumptions
+- contracts, boundaries, guardrails, and failure modes
+- concrete system behavior instead of abstract summaries
+- compact paragraphs with high signal
+- occasional dry humor when it sharpens the argument
+
+## What To Avoid
+
+- marketing tone or generic thought-leadership phrasing
+- step-by-step tutorial drift unless the prompt truly asks for it
+- fake balance, fake humility, or softened criticism
+- explicit credential signaling such as role-title authority
+- abstract claims with no system behavior or consequence
+- filler transitions or padded conclusions
+
+## Editing Test
+
+Before calling a draft strong enough, check:
+
+- does it sound like engineer-to-engineer reasoning rather than content marketing?
+- does it move through problem, mechanism, and consequence?
+- does it name at least one concrete failure mode, tradeoff, or system pattern?
+- does the ending leave the reader with a usable judgment or heuristic?

--- a/.codex/docs/prompt-recipes.md
+++ b/.codex/docs/prompt-recipes.md
@@ -44,7 +44,7 @@ Migrate this Medium article into a site-native draft, fact-check anything time-s
 
 ## Focused Skills
 
-`Use $content-brainstormer to propose three authority-first post ideas about debugging brittle mobile systems.`
+`Use $content-brainstormer to propose three insight-led post ideas about debugging brittle mobile systems.`
 
 `Use $fact-checker to verify these claims and tell me what needs stronger sourcing.`
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _drafts/
 # Local tooling caches
 .pre-commit-cache/
 .venv-tools/
+.glassbox/latest-review.md
+.glassbox/review-mmpulsetc8qlyfby.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@
   - `fact_check_status`
   - final publish QA
 - Cover images are usually remote Unsplash URLs supplied in the prompt. Local image assets are the exception.
-- Topic development should bias toward authority-building topics in mobile architecture, debugging, systems thinking, AI engineering, and principal mobile engineering leadership.
+- Topic development should bias toward insight-led topics in mobile architecture, debugging,
+  systems thinking, AI engineering, and mobile engineering leadership.
 
 ## Solo Integration Policy
 
@@ -100,7 +101,7 @@
 ## Repo-Local Skills
 
 - `jekyll-post-publisher`: Create private drafts, validate them, run publish QA, and promote them into tracked posts.
-- `content-brainstormer`: Generate authority-first topic ideas, hooks, outlines, and backlog candidates.
+- `content-brainstormer`: Generate experience-driven topic ideas, hooks, outlines, and backlog candidates.
 - `technical-post-drafter`: Turn outlines, notes, and rough drafts into strong technical article bodies before fact checking and publish QA.
 - `fact-checker`: Verify technical and time-sensitive claims with primary sources and official documentation.
 - `medium-porter`: Convert and polish Medium posts into site-native Jekyll content.

--- a/_includes/json-ld.html
+++ b/_includes/json-ld.html
@@ -1,5 +1,29 @@
-{%- comment -%}
-Jekyll SEO Tag already emits canonical JSON-LD for this site. Keep this partial as a documented
-no-op so repo-local audits can require the include without duplicating schema.org BlogPosting
-blocks in the head.
-{%- endcomment -%}
+{%- if page.layout == "single" and page.date -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ page.title | jsonify }},
+  "description": {{ page.description | default: page.excerpt | strip_html | strip_newlines | truncate: 200 | jsonify }},
+  "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
+  "dateModified": {{ page.last_modified_at | default: page.date | date_to_xmlschema | jsonify }},
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": {{ page.url | absolute_url | jsonify }}
+  },
+  "url": {{ page.url | absolute_url | jsonify }},
+  "author": {
+    "@type": "Person",
+    "name": {{ page.author | default: site.author.name | jsonify }}
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": {{ site.title | jsonify }},
+    "logo": {
+      "@type": "ImageObject",
+      "url": {{ site.logo | absolute_url | jsonify }}
+    }
+  }
+}
+</script>
+{%- endif -%}

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -2,6 +2,7 @@
 title: "Page Not Found"
 description: "Page not found. Your pixels are in another canvas."
 excerpt: "Page not found. Your pixels are in another canvas."
+layout: single
 sitemap: false
 robots: noindex, nofollow
 permalink: /404.html

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,6 +1,6 @@
 ---
 title: "Hi, I'm Shabib"
-description: "Engineering blog on principal mobile architecture, debugging philosophy, and cross-platform strategy. Written by a principal mobile engineer."
+description: "Engineering blog on mobile architecture, debugging, and cross-platform strategy. Experience-driven writing about systems, tradeoffs, and engineering consequences."
 permalink: /
 layout: single
 author_profile: true

--- a/_pages/tag-archive.md
+++ b/_pages/tag-archive.md
@@ -1,10 +1,10 @@
 ---
 title: "Posts by Tag"
-tagline: "Explore all blog posts by tag—covering debugging, mobile architecture, system design, and principal engineering leadership topics."
+tagline: "Explore all blog posts by tag—covering debugging, mobile architecture, system design, and engineering tradeoffs."
 permalink: /tags/
 layout: tags
 author_profile: true
-description: "Explore all blog posts by tag—covering debugging, mobile architecture, system design, and principal engineering leadership topics."
+description: "Explore all blog posts by tag—covering debugging, mobile architecture, system design, and engineering tradeoffs."
 sitemap: true
 robots: index, follow
 ---

--- a/scripts/audit-skill.sh
+++ b/scripts/audit-skill.sh
@@ -180,7 +180,7 @@ def fit_assessment(skill)
   end
 
   if normalized_text(skill).match?(/voice|hook|outline|example|thesis/)
-    notes << "supports the site's authority-first technical writing style"
+    notes << "supports the site's insight-led engineering writing style"
   end
 
   [level, notes.uniq]


### PR DESCRIPTION
## Summary

- editorial skill system updates

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Validation

- `make qa-local`

## Affected Files

```text
.agents/skills/content-brainstormer/SKILL.md
.agents/skills/content-brainstormer/agents/openai.yaml
.agents/skills/content-brainstormer/evals/eval_queries.json
.agents/skills/content-brainstormer/evals/evals.json
.agents/skills/content-brainstormer/references/editorial-calendar.md
.agents/skills/content-brainstormer/references/positioning.md
.agents/skills/content-brainstormer/references/topic-selection.md
.agents/skills/fact-checker/SKILL.md
.agents/skills/fact-checker/agents/openai.yaml
.agents/skills/fact-checker/evals/eval_queries.json
.agents/skills/fact-checker/evals/evals.json
.agents/skills/historical-post-editor/SKILL.md
.agents/skills/historical-post-editor/agents/openai.yaml
.agents/skills/historical-post-editor/evals/eval_queries.json
.agents/skills/historical-post-editor/evals/evals.json
.agents/skills/historical-post-editor/evals/files/2024-08-15-metrics-hide-failure.md
.agents/skills/historical-post-editor/references/preservation-rules.md
.agents/skills/historical-post-editor/scripts/assert-protected-post-fields.sh
.agents/skills/jekyll-post-publisher/SKILL.md
.agents/skills/jekyll-post-publisher/agents/openai.yaml
.agents/skills/jekyll-post-publisher/evals/evals.json
.agents/skills/jekyll-post-publisher/evals/files/draft-body-only.md
.agents/skills/jekyll-post-publisher/evals/files/draft-metadata-incomplete.md
.agents/skills/jekyll-post-publisher/scripts/validate-post.sh
.agents/skills/medium-porter/SKILL.md
.agents/skills/medium-porter/agents/openai.yaml
.agents/skills/medium-porter/evals/eval_queries.json
.agents/skills/medium-porter/evals/evals.json
.agents/skills/medium-porter/evals/files/medium-runtime-contract.md
.agents/skills/technical-post-drafter/SKILL.md
.agents/skills/technical-post-drafter/agents/openai.yaml
.agents/skills/technical-post-drafter/evals/eval_queries.json
.agents/skills/technical-post-drafter/evals/evals.json
.agents/skills/technical-post-drafter/references/article-structure.md
.agents/skills/technical-post-drafter/references/drafting-rules.md
.codex/docs/editorial-policy.md
.codex/docs/editorial-skill-trigger-evals.md
.codex/docs/editorial-voice-eval-rubric.md
.codex/docs/editorial-voice-profile.md
.codex/docs/prompt-recipes.md
.gitignore
AGENTS.md
_pages/about.md
_pages/tag-archive.md
scripts/audit-skill.sh
```

## Affected URLs

```text
/when-metrics-hide-the-real-failure/
/when-platform-leverage-gets-treated-like-implementation-detail/
/
/tags/
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
