### PR TITLE
chore: ruby dependency warning hardening

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ ruby "3.4.4"
 
 gem "github-pages", group: :jekyll_plugins
 
+# Explicitly include runtime deps now split or no longer default in newer runtimes.
+gem "faraday-retry"
+gem "ostruct"
+
 gem "tzinfo-data"
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -290,6 +292,7 @@ GEM
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
+    ostruct (0.6.3)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     progressbar (1.13.0)
@@ -338,6 +341,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  faraday-retry
   github-pages
   jekyll-algolia
   jekyll-feed
@@ -347,6 +351,7 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   jemoji
+  ostruct
   tzinfo-data
 
 RUBY VERSION


### PR DESCRIPTION
## Summary

- ruby dependency warning hardening

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Validation

- `make qa-local`

## Affected Files

```text
Gemfile
Gemfile.lock
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
