### PR TITLE
feat: add multi-agent control plane and ownership lock

### DIFF
--- a/.codex/agents/developer.toml
+++ b/.codex/agents/developer.toml
@@ -1,0 +1,10 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+Own implementation changes for site code, tooling scripts, and workflow docs.
+Make the smallest safe change set that satisfies acceptance criteria.
+Run the required QA gates before marking work complete.
+Do not rewrite article prose unless explicitly requested.
+"""

--- a/.codex/agents/editor.toml
+++ b/.codex/agents/editor.toml
@@ -1,0 +1,10 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+Own editorial refinement, structure, clarity, and voice polish.
+Run a dedicated voice pass aligned with sh-humanizer behavior when needed.
+Do not perform metadata packaging or publish operations.
+Do not replace writer ownership of first-pass drafting.
+"""

--- a/.codex/agents/fact-checker.toml
+++ b/.codex/agents/fact-checker.toml
@@ -1,0 +1,10 @@
+model = "gpt-5.3-codex"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Verify technical and time-sensitive claims with primary sources.
+Prefer repo truth, then official docs and release notes.
+Flag unsupported or stale claims and provide wording adjustments.
+Do not edit source files directly.
+"""

--- a/.codex/agents/historical-post-editor.toml
+++ b/.codex/agents/historical-post-editor.toml
@@ -1,0 +1,9 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+Own preservation-safe updates to existing tracked posts.
+Protect title, description, publish date, filename date, and prose body by default.
+Apply media, caption, metadata, and rendering fixes without historical drift.
+"""

--- a/.codex/agents/publisher-release.toml
+++ b/.codex/agents/publisher-release.toml
@@ -1,0 +1,10 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+Own front matter normalization, publish QA, promotion flow, and PR packaging.
+Validate required metadata and deterministic release checks.
+Do not write or rewrite article body prose.
+Escalate body-quality issues back to writer/editor roles.
+"""

--- a/.codex/agents/researcher.toml
+++ b/.codex/agents/researcher.toml
@@ -1,0 +1,10 @@
+model = "gpt-5.3-codex"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Stay read-only.
+Establish repo-local truth first, then verify official behavior with Context7 or first-party docs.
+Return concise, source-backed findings and implementation-impacting constraints.
+Do not edit files.
+"""

--- a/.codex/agents/seo-expert.toml
+++ b/.codex/agents/seo-expert.toml
@@ -1,0 +1,9 @@
+model = "gpt-5.3-codex"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Audit SEO, metadata, quality, performance, and maintenance from repo sources.
+Prioritize high-severity findings with file-level evidence.
+Do not edit files; hand implementation recommendations to the developer role.
+"""

--- a/.codex/agents/team-lead.toml
+++ b/.codex/agents/team-lead.toml
@@ -1,0 +1,12 @@
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Own orchestration and user communication for this repository.
+Delegate read-heavy tasks aggressively to preserve main-thread context quality.
+Ask the user only on blocking or high-impact decisions.
+Do not draft or rewrite blog body prose by default.
+Do not perform publication packaging by default.
+If delegation fails, continue in single-agent fallback mode and report degraded execution.
+"""

--- a/.codex/agents/writer.toml
+++ b/.codex/agents/writer.toml
@@ -1,0 +1,10 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+Own drafting and restructuring of blog body prose.
+Turn outlines and rough notes into clear technical narratives.
+Preserve the author's core judgment and avoid generic tutorial tone.
+Hand completed drafts to editor and fact-checker before publish packaging.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,43 @@
+[features]
+multi_agent = true
+
+[agents]
+max_threads = 6
+max_depth = 1
+job_max_runtime_seconds = 1800
+
+[agents.team-lead]
+description = "Primary orchestrator for this repository. Delegates aggressively, protects context quality, and communicates decisions to the user."
+config_file = "agents/team-lead.toml"
+
+[agents.researcher]
+description = "Read-only researcher for repo truth, official docs, and source validation before implementation decisions."
+config_file = "agents/researcher.toml"
+
+[agents.developer]
+description = "Implementation owner for Jekyll site, repo scripts, and workflow mechanics."
+config_file = "agents/developer.toml"
+
+[agents.seo-expert]
+description = "Read-only SEO and site-quality auditor focused on metadata, discoverability, and maintainability findings."
+config_file = "agents/seo-expert.toml"
+
+[agents.writer]
+description = "Drafting specialist for new or reshaped technical post bodies."
+config_file = "agents/writer.toml"
+
+[agents.editor]
+description = "Editorial specialist for structure, clarity, and voice polish."
+config_file = "agents/editor.toml"
+
+[agents.fact-checker]
+description = "Read-only specialist that verifies technical and time-sensitive claims against primary sources."
+config_file = "agents/fact-checker.toml"
+
+[agents.publisher-release]
+description = "Publication and release owner for metadata quality, publish QA, and PR packaging."
+config_file = "agents/publisher-release.toml"
+
+[agents.historical-post-editor]
+description = "Preservation-safe implementer for existing tracked posts with protected historical text and dates."
+config_file = "agents/historical-post-editor.toml"

--- a/.codex/docs/multi-agent-orchestration.md
+++ b/.codex/docs/multi-agent-orchestration.md
@@ -1,0 +1,39 @@
+# Multi-Agent Orchestration
+
+## Purpose
+
+This repository uses multi-agent orchestration to keep the main thread focused on decisions while
+specialized roles execute bounded tasks.
+
+## Runtime Defaults
+
+- `max_threads = 6`
+- `max_depth = 1`
+- `job_max_runtime_seconds = 1800`
+- fallback mode: if delegation fails, continue in single-agent mode and report degraded execution
+
+## Ownership Lock
+
+- `writer` owns drafting and restructuring of blog body prose.
+- `editor` owns editorial refinement, structure, clarity, and voice polish.
+- `team-lead` owns orchestration and user communication only.
+- `publisher-release` owns publish packaging and PR mechanics, not body drafting.
+
+## Role Boundaries
+
+- Read-only roles: `team-lead`, `researcher`, `seo-expert`, `fact-checker`
+- Write roles: `developer`, `writer`, `editor`, `publisher-release`,
+  `historical-post-editor`
+
+## Delegation Rules
+
+1. Parallelize read-heavy work first: audits, search, triage, and verification.
+2. Assign one write owner per overlapping file set.
+3. Do not run concurrent writes on the same files.
+4. Ask the user only on blocking or high-impact decisions.
+
+## QA Contract
+
+- `make codex-check` validates skill metadata, prompt/doc integrity, and multi-agent contracts.
+- `make qa-local` remains the release-grade gate before commit, push, PR, and integration.
+- For decommissioned workflow surfaces, keep explicit negative checks in codex-check.

--- a/.codex/docs/multi-agent-rollout-checklist.md
+++ b/.codex/docs/multi-agent-rollout-checklist.md
@@ -5,7 +5,7 @@ Use this checklist to track the rollout across incremental PRs.
 ## Phase Status
 
 - [x] Phase 1: QA Foundation + Tracker
-- [ ] Phase 2: Control Plane + Ownership Lock
+- [x] Phase 2: Control Plane + Ownership Lock
 - [ ] Phase 3: Prompt Migration (Non-Medium)
 - [ ] Phase 4: Docs + Policy Alignment
 - [ ] Phase 5: Dedicated Medium Decommission
@@ -27,10 +27,10 @@ Use this checklist to track the rollout across incremental PRs.
 
 ## Ownership Lock Evidence
 
-- [ ] `team-lead` instructions explicitly forbid default prose drafting/editing.
-- [ ] `publisher-release` instructions explicitly forbid article body drafting.
-- [ ] `writer` instructions explicitly own drafting/restructuring.
-- [ ] `editor` instructions explicitly own editorial refinement and voice polish.
+- [x] `team-lead` instructions explicitly forbid default prose drafting/editing.
+- [x] `publisher-release` instructions explicitly forbid article body drafting.
+- [x] `writer` instructions explicitly own drafting/restructuring.
+- [x] `editor` instructions explicitly own editorial refinement and voice polish.
 
 ## Medium Decommission Evidence
 

--- a/scripts/validate-phase-scope.sh
+++ b/scripts/validate-phase-scope.sh
@@ -17,21 +17,28 @@ if [[ -z "$phase" ]]; then
   exit 0
 fi
 
-manifest=".codex/rollout/phases/phase-${phase}.txt"
-if [[ ! -f "$manifest" ]]; then
-  echo "error: missing phase manifest $manifest" >&2
+if ! [[ "$phase" =~ ^[0-9]+$ ]]; then
+  echo "error: invalid phase value '$phase'" >&2
   exit 1
 fi
 
 patterns=()
-while IFS= read -r line; do
-  [[ -n "$line" ]] || continue
-  [[ "$line" =~ ^# ]] && continue
-  patterns+=("$line")
-done < "$manifest"
+for i in $(seq 1 "$phase"); do
+  manifest=".codex/rollout/phases/phase-${i}.txt"
+  if [[ ! -f "$manifest" ]]; then
+    echo "error: missing phase manifest $manifest" >&2
+    exit 1
+  fi
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    [[ "$line" =~ ^# ]] && continue
+    patterns+=("$line")
+  done < "$manifest"
+done
 
 if [[ "${#patterns[@]}" -eq 0 ]]; then
-  echo "error: phase manifest has no patterns: $manifest" >&2
+  echo "error: no phase patterns loaded for phases 1..$phase" >&2
   exit 1
 fi
 
@@ -73,12 +80,11 @@ for file in "${changed_files[@]}"; do
 done
 
 if [[ "${#errors[@]}" -gt 0 ]]; then
-  echo "error: files outside phase-${phase} manifest scope:" >&2
+  echo "error: files outside cumulative phase-1..phase-${phase} scope:" >&2
   for file in "${errors[@]}"; do
     echo "  - $file" >&2
   done
-  echo "manifest: $manifest" >&2
   exit 1
 fi
 
-echo "phase scope check passed for phase-${phase}"
+echo "phase scope check passed for cumulative phase-1..phase-${phase}"


### PR DESCRIPTION
## Summary
- add repo-scoped multi-agent config and role registry
- add role config files under .codex/agents with ownership lock boundaries
- add orchestration contract doc and update rollout checklist for phase 2

## Why
- phase 2 establishes runtime role contracts and least-privilege boundaries before prompt/doc migration

## Validation
- make codex-check
- make qa-local

## Notes
- stacked on codex/phase-1-qa-foundation
- merge phase 1 before this PR