### PR TITLE
feat: migrate active workflows to orchestrator prompts

### DIFF
--- a/.codex/docs/multi-agent-rollout-checklist.md
+++ b/.codex/docs/multi-agent-rollout-checklist.md
@@ -6,7 +6,7 @@ Use this checklist to track the rollout across incremental PRs.
 
 - [x] Phase 1: QA Foundation + Tracker
 - [x] Phase 2: Control Plane + Ownership Lock
-- [ ] Phase 3: Prompt Migration (Non-Medium)
+- [x] Phase 3: Prompt Migration (Non-Medium)
 - [ ] Phase 4: Docs + Policy Alignment
 - [ ] Phase 5: Dedicated Medium Decommission
 - [ ] Phase 6: Canary + Stabilization

--- a/.codex/docs/prompt-recipes.md
+++ b/.codex/docs/prompt-recipes.md
@@ -3,43 +3,19 @@
 ## Site Work In VS Code / Cursor
 
 ```text
-@.codex/prompts/site-workflow.md Review the about page and tag archive for SEO, metadata, and maintenance issues, make the fixes, run the relevant audits, run make qa-local, and open the PR.
-```
-
-## Site Work In The Codex App
-
-```text
-$site-quality-auditor $official-doc-verifier $repo-flow
-
-Review the about page and tag archive for SEO, metadata, and maintenance issues, make the fixes, run the relevant audits, run make qa-local, group clean commits, and open the PR.
+@.codex/prompts/orchestrator-site-workflow.md Review the about page and tag archive for SEO, metadata, and maintenance issues, make the fixes, run the relevant audits, run make qa-local, and open the PR.
 ```
 
 ## Draft + Publish In VS Code / Cursor
 
 ```text
-@.codex/prompts/editorial-workflow.md Turn this outline into a private draft in _drafts, fact-check the technical claims, publish it into _posts with the correct date, run QA, and open the PR: ...
+@.codex/prompts/orchestrator-editorial-workflow.md Turn this outline into a private draft in _drafts, fact-check the technical claims, publish it into _posts with the correct date, run QA, and open the PR: ...
 ```
 
-## Draft + Publish In The Codex App
+## Preserve Existing Post In VS Code / Cursor
 
 ```text
-$content-brainstormer $technical-post-drafter $fact-checker $jekyll-post-publisher $repo-flow
-
-Turn this outline into a private draft in _drafts, fact-check the technical claims, publish it into _posts with the correct date, run QA, group clean commits, and open the PR: ...
-```
-
-## Medium To Blog In VS Code / Cursor
-
-```text
-@.codex/prompts/medium-to-blog.md Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, and open the PR: https://medium.com/example-post
-```
-
-## Medium To Blog In The Codex App
-
-```text
-$medium-porter $fact-checker $jekyll-post-publisher $repo-flow
-
-Migrate this Medium article into a site-native draft, fact-check anything time-sensitive, publish it into _posts, run QA, group clean commits, and open the PR: https://medium.com/example-post
+@.codex/prompts/orchestrator-preserve-existing-post.md Add a relevant inline image, fix SEO metadata, preserve historical text/date fields, run QA, and open the PR: _posts/2025-10-01-example.md
 ```
 
 ## Focused Skills
@@ -48,4 +24,4 @@ Migrate this Medium article into a site-native draft, fact-check anything time-s
 
 `Use $fact-checker to verify these claims and tell me what needs stronger sourcing.`
 
-`Use $official-doc-verifier to confirm the official docs for this tool before we encode the workflow behavior.`
+`Use $official-doc-verifier to confirm official behavior before we encode workflow logic.`

--- a/.codex/prompts/editorial-workflow.md
+++ b/.codex/prompts/editorial-workflow.md
@@ -2,28 +2,20 @@
 
 Use this repository's full net-new post workflow from topic or outline to published post and PR.
 
-- Use `$content-brainstormer` when the angle, hook, or outline is still fuzzy.
-- Use `$technical-post-drafter` to turn notes or outlines into a strong draft body.
-- Use `$fact-checker` for technical or time-sensitive claims before calling the post publish-ready.
-- Use `$jekyll-post-publisher` for draft creation, front matter, validation, publish QA, and
-  promotion into `_posts/`.
-- Use `$repo-flow` once tracked files exist and the work needs branch, commit, and PR packaging.
-- If the work is a Medium migration, use `.codex/prompts/medium-to-blog.md` instead.
-- If the work is an edit to an existing tracked post where the title, description, publish date,
-  and prose must stay intact, use `.codex/prompts/preserve-existing-post.md` instead.
-- Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=feat`.
-- Create or refine the private draft under `_drafts/`.
-- Ensure the draft has publish-ready metadata before publication.
-- Use the repo's standard article-media pattern for any editorial image blocks:
-  `figure.post-figure` with an attached `figcaption`.
-- Editorial images should use the shared blog treatment: fixed responsive height, flexible width,
-  and cropped `object-fit: cover` presentation without stretching.
+Preferred starter: `.codex/prompts/orchestrator-editorial-workflow.md`
+
+Compatibility note:
+This prompt remains available for one cycle and routes to the orchestrator workflow.
+
+- `writer` owns drafting/restructuring using `$technical-post-drafter`.
+- `editor` owns refinement and voice polish.
+- `team-lead` orchestrates and does not draft by default.
+- Use `$fact-checker` for technical or time-sensitive claims.
+- Use `$jekyll-post-publisher` for metadata, validation, publish QA, and promotion into `_posts/`.
+- Use `$repo-flow` once tracked files need branch, commit, and PR packaging.
+- Legacy import workflow is retired for this repository.
 - Run:
   `make validate-draft PATH=_drafts/<draft>.md`
   `make qa-publish PATH=_drafts/<draft>.md`
   `make publish-draft PATH=_drafts/<draft>.md DATE=YYYY-MM-DD`
-- After `_posts/` is updated, run `make qa-local`.
-- Group clean Conventional Commits only after QA passes.
-- Re-run `make qa-local` on the committed tree.
-- Run `make create-pr TYPE=feat`.
-- Finish only when the tracked post exists in `_posts/` and the PR is open.
+  `make qa-local`

--- a/.codex/prompts/orchestrator-editorial-workflow.md
+++ b/.codex/prompts/orchestrator-editorial-workflow.md
@@ -1,0 +1,16 @@
+# Orchestrator Editorial Workflow
+
+Use this workflow for net-new post creation from topic or outline through publish QA and PR.
+
+- Team lead orchestrates role handoffs and decision checkpoints.
+- Route ideation to `$content-brainstormer` when needed.
+- Route body drafting to writer behavior using `$technical-post-drafter`.
+- Route editing and voice polish to editor behavior, including `sh-humanizer` style expectations.
+- Route claims to `$fact-checker` before publish-ready status.
+- Route metadata, validation, and publication packaging to `$jekyll-post-publisher`.
+- Run:
+  `make validate-draft PATH=_drafts/<draft>.md`
+  `make qa-publish PATH=_drafts/<draft>.md`
+  `make publish-draft PATH=_drafts/<draft>.md DATE=YYYY-MM-DD`
+  `make qa-local`
+- Legacy import workflow is retired for this repository.

--- a/.codex/prompts/orchestrator-preserve-existing-post.md
+++ b/.codex/prompts/orchestrator-preserve-existing-post.md
@@ -1,0 +1,10 @@
+# Orchestrator Preserve Existing Post Workflow
+
+Use this workflow for preservation-safe updates to existing tracked posts.
+
+- Team lead orchestrates scope and guardrails.
+- Route edits to `$historical-post-editor` behavior.
+- Route site-level metadata and quality checks to `$site-quality-auditor`.
+- Preserve title, description, publish date, filename date, and prose body unless user explicitly requests changes.
+- Validate protected fields with `scripts/assert-protected-post-fields.sh`.
+- Run `make qa-local` before commit and PR packaging.

--- a/.codex/prompts/orchestrator-site-workflow.md
+++ b/.codex/prompts/orchestrator-site-workflow.md
@@ -1,0 +1,15 @@
+# Orchestrator Site Workflow
+
+Use this workflow when the user needs site changes through QA and PR packaging.
+
+- Team lead orchestrates task decomposition and user communication.
+- Route source-level findings to `$site-quality-auditor` and `$official-doc-verifier`.
+- Route file edits to `developer` behavior.
+- Keep writer/editor roles out of site-only implementation unless prose editing is requested.
+- Run relevant audits:
+  `make site-audit AUDIT=seo TARGET=...`
+  `make site-audit AUDIT=quality TARGET=...`
+  `make site-audit AUDIT=maintenance TARGET=...`
+  `make site-audit AUDIT=performance TARGET=...`
+- Run `make qa-local` before commit.
+- Finish with repo flow and PR packaging.

--- a/.codex/prompts/preserve-existing-post.md
+++ b/.codex/prompts/preserve-existing-post.md
@@ -3,31 +3,14 @@
 Use this repository's preservation-first workflow for improving an existing tracked post without
 changing its historical text or dates.
 
-- Use `$historical-post-editor` to make safe media, styling, and SEO improvements while freezing:
-  - title
-  - description
-  - publish date
-  - `_posts` filename date
-  - prose body text
-- Use `$site-quality-auditor` for SEO, quality, and maintenance checks when shared site files or
-  metadata behavior changes.
+Preferred starter: `.codex/prompts/orchestrator-preserve-existing-post.md`
+
+Compatibility note:
+This prompt remains available for one cycle and routes to the orchestrator workflow.
+
+- Use `$historical-post-editor` for safe media, styling, and SEO improvements.
+- Use `$site-quality-auditor` when shared metadata behavior changes.
 - Use `$repo-flow` for branch creation, grouped commits, QA, and PR packaging.
-- Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=fix`.
-- Before editing, snapshot the protected post fields and verify they still match after the changes.
-- Allowed changes by default:
-  - add or replace a relevant inline image
-  - add or replace a relevant header image when explicitly requested
-  - convert image credit or subtitle text into `figure.post-figure` and `figcaption`
-  - apply the standard smaller italic caption styling
-  - normalize inline images to the shared fixed-height, flexible-width, cropped blog style
-  - fix OG, Twitter, JSON-LD, canonical, and related metadata behavior
-  - normalize media rendering bugs
-  - update categories, tags, and `last_modified_at` when appropriate
-- Do not rewrite title, description, publish date, or prose body unless the user explicitly asks.
-- Run `scripts/assert-protected-post-fields.sh` against the before and after versions when the
-  task is in preservation mode.
-- After the changes are complete, run `make qa-local`.
-- Group the work into multiple relevant Conventional Commits only after QA passes.
-- Re-run `make qa-local` on the committed tree.
-- Run `make create-pr TYPE=fix`.
-- Finish only when the protected fields are still intact and the PR is open.
+- Snapshot and validate protected fields before and after edits.
+- Run `scripts/assert-protected-post-fields.sh` for preservation mode.
+- Run `make qa-local` before commit and PR creation.

--- a/.codex/prompts/site-workflow.md
+++ b/.codex/prompts/site-workflow.md
@@ -2,22 +2,15 @@
 
 Use this repository's full site-change workflow from request to PR.
 
+Preferred starter: `.codex/prompts/orchestrator-site-workflow.md`
+
+Compatibility note:
+This prompt remains available for one cycle and routes to the orchestrator workflow.
+
 - Use `$site-quality-auditor` for repo-specific site review and fixes.
-- Use `$official-doc-verifier` when Jekyll, Minimal Mistakes, Codex, or another tool has
-  version-sensitive behavior.
+- Use `$official-doc-verifier` when behavior is version-sensitive.
 - Use `$repo-flow` for branch creation, QA, commit grouping, and PR packaging.
-- Start repo-changing work from `main` with `make start-work TOPIC="..." TYPE=...`.
-- Inspect the affected files before editing.
-- Choose the relevant audit modes and run the matching commands:
-  `make site-audit AUDIT=seo TARGET=...`
-  `make site-audit AUDIT=quality TARGET=...`
-  `make site-audit AUDIT=maintenance TARGET=...`
-  `make site-audit AUDIT=performance TARGET=...` when performance review is relevant.
-- Make the required repo changes.
-- If site-facing files changed, require a local preview with `bundle exec jekyll serve` before
-  commit.
-- Run `make qa-local`.
-- Group clean Conventional Commits only after QA passes.
-- Re-run `make qa-local` on the committed tree.
-- Run `make create-pr TYPE=...`.
-- Finish only when the PR is open and ready for self-review.
+- Start from `main` with `make start-work TOPIC="..." TYPE=...`.
+- Run relevant `make site-audit` modes and then `make qa-local`.
+- If site-facing files changed, preview with `bundle exec jekyll serve` before commit.
+- Re-run `make qa-local` on the committed tree before PR creation.

--- a/scripts/run-codex-checks.sh
+++ b/scripts/run-codex-checks.sh
@@ -109,8 +109,13 @@ if File.file?(codex_usage_path) && File.file?(docs_readme_path)
   codex_usage = File.read(codex_usage_path)
   docs_readme = File.read(docs_readme_path)
 
+  use_orchestrator_starters =
+    phase_num >= 4 ||
+      (codex_usage.include?("@.codex/prompts/orchestrator-site-workflow.md") &&
+       docs_readme.include?("@.codex/prompts/orchestrator-site-workflow.md"))
+
   starter_needles =
-    if phase_num >= 3 || File.file?(File.join(repo_root, ".codex", "prompts", "orchestrator-site-workflow.md"))
+    if use_orchestrator_starters
       [
         "@.codex/prompts/orchestrator-site-workflow.md",
         "@.codex/prompts/orchestrator-editorial-workflow.md",


### PR DESCRIPTION
## Summary
- add orchestrator prompt starters for site, editorial, and preservation workflows
- update legacy prompt files to compatibility routing
- update prompt recipes and rollout checklist for phase 3

## Why
- phase 3 moves active workflow entrypoints to orchestration-first prompts

## Validation
- make codex-check
- make qa-local

## Notes
- stacked on codex/phase-2-control-plane
- merge phase 2 before this PR