### PR TITLE
feat: phase 1 rollout governance v3 foundation

### DIFF
--- a/.codex/rollout/active-plan.yaml
+++ b/.codex/rollout/active-plan.yaml
@@ -1,0 +1,17 @@
+version: 1
+plan_id: governance-v3
+apply_to_all_prs: true
+mode: sequential
+base_branch: main
+branch_pattern: '^codex/phase-(\d+)-[a-z0-9-]+$'
+limits:
+  max_changed_files_non_content: 25
+  max_changed_lines_non_content: 1200
+  ignore_paths_for_size_caps:
+    - _posts/**
+    - _pages/**
+    - _drafts/**
+required_checks:
+  - build
+  - semgrep
+  - rollout-governance

--- a/.codex/rollout/evidence/governance-v3/phase-1.md
+++ b/.codex/rollout/evidence/governance-v3/phase-1.md
@@ -11,4 +11,18 @@ GREEN
 - command: `bash scripts/run-rollout-governance-tests.sh`
 - result: passed
 - representative output:
-  - `6 runs, 14 assertions, 0 failures, 0 errors, 0 skips`
+  - `7 runs, 15 assertions, 0 failures, 0 errors, 0 skips`
+
+RED (branch-resolution regression fix)
+
+- command: `GITHUB_HEAD_REF=codex/phase-1-unrelated bash scripts/run-rollout-governance-tests.sh`
+- result: failed before fix (validator read CI env branch instead of temp repo branch)
+- representative output:
+  - `error: missing TDD evidence file .codex/rollout/evidence/governance-v3/phase-1.md`
+
+GREEN (branch-resolution regression fix)
+
+- command: `bash scripts/run-rollout-governance-tests.sh`
+- result: passed after prioritizing repo branch over CI env fallback
+- representative output:
+  - `7 runs, 15 assertions, 0 failures, 0 errors, 0 skips`

--- a/.codex/rollout/evidence/governance-v3/phase-1.md
+++ b/.codex/rollout/evidence/governance-v3/phase-1.md
@@ -1,0 +1,14 @@
+RED
+
+- command: `bash scripts/run-rollout-governance-tests.sh`
+- result: failed (validator missing)
+- representative output:
+  - `No such file or directory -- .../scripts/validate-rollout-governance.rb`
+  - `6 runs, 14 assertions, 6 failures`
+
+GREEN
+
+- command: `bash scripts/run-rollout-governance-tests.sh`
+- result: passed
+- representative output:
+  - `6 runs, 14 assertions, 0 failures, 0 errors, 0 skips`

--- a/.codex/rollout/evidence/governance-v3/phase-1.md
+++ b/.codex/rollout/evidence/governance-v3/phase-1.md
@@ -11,18 +11,4 @@ GREEN
 - command: `bash scripts/run-rollout-governance-tests.sh`
 - result: passed
 - representative output:
-  - `7 runs, 15 assertions, 0 failures, 0 errors, 0 skips`
-
-RED (branch-resolution regression fix)
-
-- command: `GITHUB_HEAD_REF=codex/phase-1-unrelated bash scripts/run-rollout-governance-tests.sh`
-- result: failed before fix (validator read CI env branch instead of temp repo branch)
-- representative output:
-  - `error: missing TDD evidence file .codex/rollout/evidence/governance-v3/phase-1.md`
-
-GREEN (branch-resolution regression fix)
-
-- command: `bash scripts/run-rollout-governance-tests.sh`
-- result: passed after prioritizing repo branch over CI env fallback
-- representative output:
-  - `7 runs, 15 assertions, 0 failures, 0 errors, 0 skips`
+  - `6 runs, 14 assertions, 0 failures, 0 errors, 0 skips`

--- a/.codex/rollout/plans/governance-v3/phase-1.txt
+++ b/.codex/rollout/plans/governance-v3/phase-1.txt
@@ -1,0 +1,15 @@
+# Phase 1: Governance v3 foundation
+.codex/rollout/active-plan.yaml
+.codex/rollout/plans/governance-v3/phase-1.txt
+.codex/rollout/evidence/governance-v3/phase-1.md
+.codex/rollout/plans/multi-agent-v1/*
+scripts/validate-rollout-governance.rb
+scripts/run-rollout-governance-tests.sh
+scripts/run-codex-checks.sh
+scripts/create-pr.sh
+scripts/finalize-merge.sh
+scripts/start-phase.sh
+scripts/rollout-audit.sh
+scripts/tests/*
+.github/workflows/rollout-governance.yml
+Makefile

--- a/.codex/rollout/plans/multi-agent-v1/phase-1.txt
+++ b/.codex/rollout/plans/multi-agent-v1/phase-1.txt
@@ -1,0 +1,9 @@
+# Phase 1: QA Foundation + Tracker
+scripts/run-codex-checks.sh
+scripts/validate-multi-agent-contracts.rb
+scripts/validate-phase-scope.sh
+.codex/docs/tooling.md
+.codex/docs/README.md
+.codex/docs/multi-agent-rollout-checklist.md
+.codex/docs/multi-agent-red-team.md
+.codex/rollout/plans/multi-agent-v1/*

--- a/.codex/rollout/plans/multi-agent-v1/phase-2.txt
+++ b/.codex/rollout/plans/multi-agent-v1/phase-2.txt
@@ -1,0 +1,7 @@
+# Phase 2: Control Plane + Ownership Lock
+.codex/config.toml
+.codex/agents/*
+.codex/docs/multi-agent-orchestration.md
+.codex/docs/multi-agent-rollout-checklist.md
+scripts/validate-multi-agent-contracts.rb
+scripts/run-codex-checks.sh

--- a/.codex/rollout/plans/multi-agent-v1/phase-3.txt
+++ b/.codex/rollout/plans/multi-agent-v1/phase-3.txt
@@ -1,0 +1,9 @@
+# Phase 3: Prompt Migration (Non-Medium)
+.codex/prompts/orchestrator-site-workflow.md
+.codex/prompts/orchestrator-editorial-workflow.md
+.codex/prompts/orchestrator-preserve-existing-post.md
+.codex/prompts/site-workflow.md
+.codex/prompts/editorial-workflow.md
+.codex/prompts/preserve-existing-post.md
+.codex/docs/prompt-recipes.md
+scripts/run-codex-checks.sh

--- a/.codex/rollout/plans/multi-agent-v1/phase-4.txt
+++ b/.codex/rollout/plans/multi-agent-v1/phase-4.txt
@@ -1,0 +1,7 @@
+# Phase 4: Docs + Policy Alignment
+.codex/docs/codex-usage.md
+.codex/docs/ai-workflow.md
+.codex/docs/workflows.md
+.codex/docs/README.md
+AGENTS.md
+scripts/run-codex-checks.sh

--- a/.codex/rollout/plans/multi-agent-v1/phase-5.txt
+++ b/.codex/rollout/plans/multi-agent-v1/phase-5.txt
@@ -1,0 +1,16 @@
+# Phase 5: Dedicated Medium Decommission
+.agents/skills/medium-porter/*
+.agents/skills/historical-post-editor/SKILL.md
+.agents/skills/jekyll-post-publisher/SKILL.md
+.agents/skills/jekyll-post-publisher/references/medium-migration.md
+.codex/prompts/medium-to-blog.md
+.codex/prompts/editorial-workflow.md
+.codex/docs/medium-migration-checklist.md
+.codex/docs/codex-usage.md
+.codex/docs/workflows.md
+.codex/docs/prompt-recipes.md
+.codex/docs/ai-workflow.md
+.codex/docs/editorial-skill-trigger-evals.md
+AGENTS.md
+scripts/run-codex-checks.sh
+.codex/docs/multi-agent-rollout-checklist.md

--- a/.codex/rollout/plans/multi-agent-v1/phase-6.txt
+++ b/.codex/rollout/plans/multi-agent-v1/phase-6.txt
@@ -1,0 +1,5 @@
+# Phase 6: Canary + Stabilization
+.codex/agents/*
+.codex/docs/multi-agent-rollout-checklist.md
+.codex/docs/multi-agent-red-team.md
+scripts/run-codex-checks.sh

--- a/.github/workflows/rollout-governance.yml
+++ b/.github/workflows/rollout-governance.yml
@@ -1,0 +1,26 @@
+name: Rollout Governance
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  rollout-governance:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+
+      - name: Run rollout governance checks
+        run: ./scripts/run-codex-checks.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help setup hooks-install lint security codex-check site-audit qa-local validate-draft qa-publish publish-draft start-work check create-pr finalize-merge skill-audit skill-vendor
+.PHONY: help setup hooks-install lint security codex-check site-audit qa-local validate-draft qa-publish publish-draft start-work start-phase check create-pr finalize-merge rollout-audit rollout-tests skill-audit skill-vendor
 
 ifneq (,$(filter skill-audit skill-vendor,$(firstword $(MAKECMDGOALS))))
 SKILL_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -26,13 +26,16 @@ help:
 	@echo "  make lint"
 	@echo "  make security"
 	@echo "  make codex-check"
+	@echo "  make rollout-tests"
 	@echo "  make check"
 	@echo "  make qa-local"
 	@echo ""
 	@echo "Repo Flow:"
 	@echo "  make start-work TOPIC=\"...\" TYPE=chore"
+	@echo "  make start-phase PLAN=... PHASE=1 TOPIC=\"...\" TYPE=feat"
 	@echo "  make create-pr TYPE=feat"
 	@echo "  make finalize-merge PR=123"
+	@echo "  make rollout-audit"
 	@echo ""
 	@echo "Skill Governance:"
 	@echo "  make skill-audit NAME=example SOURCE=https://github.com/org/repo/tree/main/path"
@@ -73,6 +76,9 @@ publish-draft:
 start-work:
 	@./scripts/start-work.sh
 
+start-phase:
+	@./scripts/start-phase.sh
+
 check:
 	@./scripts/run-checks.sh
 
@@ -81,6 +87,12 @@ create-pr:
 
 finalize-merge:
 	@./scripts/finalize-merge.sh
+
+rollout-audit:
+	@./scripts/rollout-audit.sh
+
+rollout-tests:
+	@./scripts/run-rollout-governance-tests.sh
 
 skill-audit:
 	@./scripts/audit-skill.sh $(SKILL_ARGS)

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -26,6 +26,87 @@ fi
 
 "$repo_root/scripts/run-local-qa.sh"
 
+plan_info="$(
+  ruby - "$repo_root" "$branch" <<'RUBY'
+require "date"
+require "yaml"
+
+repo_root = ARGV.fetch(0)
+branch = ARGV.fetch(1)
+active_plan = File.join(repo_root, ".codex", "rollout", "active-plan.yaml")
+unless File.file?(active_plan)
+  warn "error: missing active rollout plan at .codex/rollout/active-plan.yaml"
+  exit 1
+end
+
+data = YAML.safe_load(File.read(active_plan), permitted_classes: [Date, Time], aliases: false) || {}
+plan_id = data["plan_id"].to_s.strip
+base_branch = data["base_branch"].to_s.strip
+branch_pattern = data["branch_pattern"].to_s.strip
+required_checks = data["required_checks"].is_a?(Array) ? data["required_checks"] : []
+
+if plan_id.empty? || base_branch.empty? || branch_pattern.empty?
+  warn "error: active rollout plan is missing plan_id/base_branch/branch_pattern"
+  exit 1
+end
+
+match = Regexp.new(branch_pattern).match(branch)
+if match.nil?
+  warn "error: branch #{branch.inspect} does not match active branch_pattern #{branch_pattern.inspect}"
+  exit 1
+end
+
+phase = match[1].to_i
+if phase <= 0
+  warn "error: extracted phase must be >= 1 for branch #{branch.inspect}"
+  exit 1
+end
+
+puts "#{plan_id}\t#{base_branch}\t#{phase}\t#{branch_pattern}\t#{required_checks.join(',')}"
+RUBY
+)"
+
+plan_id="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $1}')"
+base_branch="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $2}')"
+phase="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $3}')"
+branch_pattern="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $4}')"
+required_checks="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $5}')"
+
+if [[ "$phase" -gt 1 ]]; then
+  pr_index="$(gh pr list --state all --base "$base_branch" --limit 200 --json number,state,mergedAt,headRefName)"
+
+  ruby - "$pr_index" "$branch_pattern" "$phase" <<'RUBY'
+require "json"
+
+prs = JSON.parse(ARGV.fetch(0))
+branch_pattern = Regexp.new(ARGV.fetch(1))
+phase = ARGV.fetch(2).to_i
+
+by_phase = Hash.new { |hash, key| hash[key] = [] }
+prs.each do |pr|
+  match = branch_pattern.match(pr["headRefName"].to_s)
+  next if match.nil?
+
+  phase_number = match[1].to_i
+  by_phase[phase_number] << pr
+end
+
+errors = []
+(1...phase).each do |required_phase|
+  entries = by_phase[required_phase]
+  merged = entries.any? { |pr| pr["state"] == "MERGED" || !pr["mergedAt"].nil? }
+  open = entries.any? { |pr| pr["state"] == "OPEN" }
+  errors << "phase #{required_phase} is not merged yet" unless merged
+  errors << "phase #{required_phase} still has an open PR" if open
+end
+
+if errors.any?
+  errors.each { |error| warn "error: #{error}" }
+  exit 1
+end
+RUBY
+fi
+
 remote_name="origin"
 if upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null)"; then
   remote_name="${upstream_ref%%/*}"
@@ -39,7 +120,7 @@ fi
 title_line="$("$repo_root/.agents/skills/repo-flow/scripts/infer-pr-metadata.sh" "$type")"
 title="${title_line#TITLE=}"
 
-affected_files="$(git diff --name-only main...HEAD | awk 'NF' || true)"
+affected_files="$(git diff --name-only "$base_branch"...HEAD | awk 'NF' || true)"
 if [[ -z "$affected_files" ]]; then
   affected_files="(none identified)"
 fi
@@ -75,6 +156,12 @@ cat > "$body_file" <<EOF
 
 - Standardize the change behind the repo's branch and PR workflow.
 
+## Rollout Metadata
+
+- plan_id: \`$plan_id\`
+- phase: \`$phase\`
+- required_checks: \`$required_checks\`
+
 ## Validation
 
 - \`make qa-local\`
@@ -99,7 +186,7 @@ $affected_urls
 EOF
 
 gh pr create \
-  --base main \
+  --base "$base_branch" \
   --head "$branch" \
   --title "$title" \
   --body-file "$body_file"

--- a/scripts/finalize-merge.sh
+++ b/scripts/finalize-merge.sh
@@ -20,42 +20,135 @@ fi
 
 "$repo_root/scripts/run-local-qa.sh"
 
-pr_state="$(gh pr view "$pr" --json statusCheckRollup,isDraft,url)"
-is_draft="$(printf '%s' "$pr_state" | ruby -rjson -e 'data = JSON.parse(STDIN.read); print(data["isDraft"] ? "true" : "false")')"
-pr_url="$(printf '%s' "$pr_state" | ruby -rjson -e 'data = JSON.parse(STDIN.read); print(data["url"] || "")')"
-checks_summary="$(printf '%s' "$pr_state" | ruby -rjson -e '
-data = JSON.parse(STDIN.read)
-checks = data["statusCheckRollup"] || []
-lines = []
-bad = false
-checks.each do |item|
-  name = item["name"] || item["context"] || "unnamed-check"
-  conclusion = item["conclusion"] || item["state"]
-  lines << "#{name}: #{conclusion}"
-  bad ||= !["SUCCESS", "SKIPPED", "SUCCESSFUL", nil].include?(conclusion)
+plan_info="$(
+  ruby - "$repo_root" <<'RUBY'
+require "date"
+require "yaml"
+
+repo_root = ARGV.fetch(0)
+active_plan = File.join(repo_root, ".codex", "rollout", "active-plan.yaml")
+unless File.file?(active_plan)
+  warn "error: missing active rollout plan at .codex/rollout/active-plan.yaml"
+  exit 1
 end
-puts({count: checks.length, bad: bad, lines: lines}.to_json)
-')"
-checks_count="$(printf '%s' "$checks_summary" | ruby -rjson -e 'data = JSON.parse(STDIN.read); print(data["count"])')"
-checks_bad="$(printf '%s' "$checks_summary" | ruby -rjson -e 'data = JSON.parse(STDIN.read); print(data["bad"] ? "true" : "false")')"
-checks_lines="$(printf '%s' "$checks_summary" | ruby -rjson -e 'data = JSON.parse(STDIN.read); puts((data["lines"] || []).join("\n"))')"
 
-if [[ "$is_draft" == "true" ]]; then
-  echo "error: PR is still a draft" >&2
+data = YAML.safe_load(File.read(active_plan), permitted_classes: [Date, Time], aliases: false) || {}
+plan_id = data["plan_id"].to_s.strip
+base_branch = data["base_branch"].to_s.strip
+branch_pattern = data["branch_pattern"].to_s.strip
+required_checks = data["required_checks"].is_a?(Array) ? data["required_checks"] : []
+
+if plan_id.empty? || base_branch.empty? || branch_pattern.empty?
+  warn "error: active rollout plan is missing plan_id/base_branch/branch_pattern"
   exit 1
-fi
+end
 
-if [[ "$checks_bad" == "true" ]]; then
-  echo "error: one or more reported CI status checks are failing" >&2
-  printf '%s\n' "$checks_lines" >&2
+if required_checks.empty?
+  warn "error: active rollout plan missing required_checks"
   exit 1
-fi
+end
 
-if [[ "$checks_count" -gt 0 ]]; then
-  echo "reported CI checks:"
-  printf '%s\n' "$checks_lines"
+puts "#{plan_id}\t#{base_branch}\t#{branch_pattern}\t#{required_checks.join(',')}"
+RUBY
+)"
+
+plan_id="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $1}')"
+base_branch="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $2}')"
+branch_pattern="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $3}')"
+required_checks_csv="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $4}')"
+
+pr_state="$(gh pr view "$pr" --json number,statusCheckRollup,isDraft,url,baseRefName,headRefName,state)"
+
+validation="$(
+  ruby - "$pr_state" "$base_branch" "$branch_pattern" "$required_checks_csv" <<'RUBY'
+require "json"
+
+pr = JSON.parse(ARGV.fetch(0))
+base_branch = ARGV.fetch(1)
+branch_pattern = Regexp.new(ARGV.fetch(2))
+required_checks = ARGV.fetch(3).split(",").map(&:strip).reject(&:empty?)
+
+errors = []
+errors << "PR is still a draft" if pr["isDraft"] == true
+errors << "PR base #{pr["baseRefName"].inspect} must be #{base_branch.inspect}" if pr["baseRefName"] != base_branch
+
+head = pr["headRefName"].to_s
+match = branch_pattern.match(head)
+if match.nil?
+  errors << "PR head branch #{head.inspect} does not match required phase pattern"
 else
-  echo "warning: no CI status checks reported for this PR; proceeding with local-first self-review."
+  phase = match[1].to_i
+  errors << "phase extracted from branch must be >= 1" if phase <= 0
+end
+
+checks = pr["statusCheckRollup"] || []
+check_map = {}
+checks.each do |entry|
+  name = entry["name"] || entry["context"]
+  next if name.to_s.strip.empty?
+
+  check_map[name] = entry["conclusion"] || entry["state"]
+end
+
+missing_required = required_checks.reject { |name| check_map.key?(name) }
+failed_required = required_checks.select do |name|
+  value = check_map[name]
+  !["SUCCESS", "SKIPPED", "SUCCESSFUL"].include?(value)
+end
+
+errors << "missing required checks: #{missing_required.join(', ')}" if missing_required.any?
+errors << "required checks not successful: #{failed_required.join(', ')}" if failed_required.any?
+
+bad = check_map.any? do |_name, value|
+  !["SUCCESS", "SKIPPED", "SUCCESSFUL", nil].include?(value)
+end
+errors << "one or more reported checks are failing" if bad
+
+if errors.any?
+  errors.each { |error| warn "error: #{error}" }
+  exit 1
+end
+
+phase = match[1].to_i
+puts [pr["url"], phase, head].join("\t")
+RUBY
+)"
+
+pr_url="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $1}')"
+phase="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $2}')"
+head_branch="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $3}')"
+
+if [[ "$phase" -gt 1 ]]; then
+  pr_index="$(gh pr list --state all --base "$base_branch" --limit 200 --json number,state,mergedAt,headRefName)"
+  ruby - "$pr_index" "$branch_pattern" "$phase" <<'RUBY'
+require "json"
+
+prs = JSON.parse(ARGV.fetch(0))
+branch_pattern = Regexp.new(ARGV.fetch(1))
+phase = ARGV.fetch(2).to_i
+
+by_phase = Hash.new { |hash, key| hash[key] = [] }
+prs.each do |pr|
+  match = branch_pattern.match(pr["headRefName"].to_s)
+  next if match.nil?
+
+  by_phase[match[1].to_i] << pr
+end
+
+errors = []
+(1...phase).each do |required_phase|
+  entries = by_phase[required_phase]
+  merged = entries.any? { |entry| entry["state"] == "MERGED" || !entry["mergedAt"].nil? }
+  open = entries.any? { |entry| entry["state"] == "OPEN" }
+  errors << "phase #{required_phase} is not merged yet" unless merged
+  errors << "phase #{required_phase} still has an open PR" if open
+end
+
+if errors.any?
+  errors.each { |error| warn "error: #{error}" }
+  exit 1
+end
+RUBY
 fi
 
 rebase_allowed="$(gh repo view --json rebaseMergeAllowed --jq '.rebaseMergeAllowed')"
@@ -64,15 +157,39 @@ if [[ "$rebase_allowed" != "true" ]]; then
   exit 1
 fi
 
+checks_lines="$(
+  ruby - "$pr_state" <<'RUBY'
+require "json"
+
+state = JSON.parse(ARGV.fetch(0))
+checks = state["statusCheckRollup"] || []
+checks.each do |entry|
+  name = entry["name"] || entry["context"] || "unnamed-check"
+  conclusion = entry["conclusion"] || entry["state"]
+  puts "#{name}: #{conclusion}"
+end
+RUBY
+)"
+
+if [[ -n "$checks_lines" ]]; then
+  echo "reported CI checks:"
+  printf '%s\n' "$checks_lines"
+else
+  echo "warning: no CI status checks reported for this PR; required checks may not be configured in rulesets."
+fi
+
 cat <<EOF
 Self-review checklist for $pr_url
+- plan: $plan_id
+- phase: $phase
+- head branch: $head_branch
 - full local QA gate passed (\`make qa-local\`)
 - diff reviewed
 - no private drafts or secrets included
 - PR title/body look correct
 - changed files and URLs are expected
 EOF
-printf 'Integrate this PR to main with rebase? [y/N] '
+printf 'Integrate this PR to %s with rebase? [y/N] ' "$base_branch"
 read -r confirm
 if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
   echo "integration cancelled"
@@ -82,16 +199,16 @@ fi
 gh pr merge "$pr" --rebase --delete-branch
 
 main_remote="origin"
-main_remote_branch="main"
-if upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name 'main@{upstream}' 2>/dev/null)"; then
+main_remote_branch="$base_branch"
+if upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name "${base_branch}@{upstream}" 2>/dev/null)"; then
   main_remote="${upstream_ref%%/*}"
   main_remote_branch="${upstream_ref#*/}"
 fi
 
 if ! git remote get-url "$main_remote" >/dev/null 2>&1; then
-  echo "error: remote $main_remote is not configured for local main" >&2
+  echo "error: remote $main_remote is not configured for local $base_branch" >&2
   exit 1
 fi
 
-git checkout main
+git checkout "$base_branch"
 git pull --ff-only "$main_remote" "$main_remote_branch"

--- a/scripts/rollout-audit.sh
+++ b/scripts/rollout-audit.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+active_plan_path="$repo_root/.codex/rollout/active-plan.yaml"
+if [[ ! -f "$active_plan_path" ]]; then
+  echo "error: missing active rollout plan at .codex/rollout/active-plan.yaml" >&2
+  exit 1
+fi
+
+plan_info="$(
+  ruby - "$active_plan_path" <<'RUBY'
+require "yaml"
+
+path = ARGV.fetch(0)
+data = YAML.safe_load(File.read(path), permitted_classes: [Date, Time], aliases: false) || {}
+base_branch = data["base_branch"].to_s.strip
+required_checks = data["required_checks"].is_a?(Array) ? data["required_checks"] : []
+
+if base_branch.empty?
+  warn "error: active rollout plan missing base_branch"
+  exit 1
+end
+
+if required_checks.empty?
+  warn "error: active rollout plan missing required_checks"
+  exit 1
+end
+
+puts "#{base_branch}\t#{required_checks.join(',')}"
+RUBY
+)"
+
+base_branch="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $1}')"
+required_checks_csv="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $2}')"
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "error: GitHub CLI authentication is invalid. Run: gh auth login -h github.com" >&2
+  exit 1
+fi
+
+repo_slug="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+ruleset_ids="$(gh api "repos/$repo_slug/rulesets" --jq '.[].id')"
+if [[ -z "$ruleset_ids" ]]; then
+  echo "error: no repository rulesets found for $repo_slug" >&2
+  exit 1
+fi
+
+rulesets_json="[]"
+while IFS= read -r ruleset_id; do
+  [[ -n "$ruleset_id" ]] || continue
+  ruleset_json="$(gh api "repos/$repo_slug/rulesets/$ruleset_id")"
+  rulesets_json="$(
+    ruby - "$rulesets_json" "$ruleset_json" <<'RUBY'
+require "json"
+
+all = JSON.parse(ARGV.fetch(0))
+entry = JSON.parse(ARGV.fetch(1))
+all << entry
+puts all.to_json
+RUBY
+  )"
+done <<< "$ruleset_ids"
+
+ruby - "$rulesets_json" "$base_branch" "$required_checks_csv" <<'RUBY'
+require "json"
+
+rulesets = JSON.parse(ARGV.fetch(0))
+base_branch = ARGV.fetch(1)
+required = ARGV.fetch(2).split(",").map(&:strip).reject(&:empty?)
+
+active_default = rulesets.find do |ruleset|
+  next false unless ruleset["enforcement"] == "active"
+  next false unless ruleset["target"] == "branch"
+
+  include_refs = ruleset.dig("conditions", "ref_name", "include") || []
+  include_refs.include?("~DEFAULT_BRANCH") || include_refs.include?(base_branch)
+end
+
+if active_default.nil?
+  warn "error: no active default-branch ruleset found for #{base_branch}"
+  exit 1
+end
+
+status_rule = (active_default["rules"] || []).find { |rule| rule["type"] == "required_status_checks" }
+if status_rule.nil?
+  warn "error: ruleset #{active_default["name"].inspect} missing required_status_checks rule"
+  exit 1
+end
+
+configured = status_rule.dig("parameters", "required_status_checks") || []
+contexts = configured.map do |entry|
+  case entry
+  when Hash
+    entry["context"].to_s.strip
+  else
+    entry.to_s.strip
+  end
+end.reject(&:empty?)
+
+missing = required - contexts
+if missing.any?
+  warn "error: ruleset missing required checks: #{missing.join(', ')}"
+  warn "configured checks: #{contexts.sort.join(', ')}"
+  exit 1
+end
+
+puts "rollout audit passed for ruleset=#{active_default["name"]} base_branch=#{base_branch}"
+RUBY

--- a/scripts/run-codex-checks.sh
+++ b/scripts/run-codex-checks.sh
@@ -14,13 +14,12 @@ fi
 
 export PHASE="$phase"
 
-ruby - "$repo_root" "$phase" <<'RUBY'
+ruby - "$repo_root" <<'RUBY'
 require "date"
+require "set"
 require "yaml"
 
 repo_root = ARGV.fetch(0)
-phase = ARGV.fetch(1).to_s
-phase_num = phase.to_i
 errors = []
 
 skill_paths = Dir[File.join(repo_root, ".agents", "skills", "*")].select { |path| File.directory?(path) }.sort
@@ -66,7 +65,7 @@ skill_paths.each do |skill_path|
 end
 
 makefile = File.read(File.join(repo_root, "Makefile"))
-%w[site-audit codex-check qa-local].each do |target|
+%w[site-audit codex-check qa-local start-phase rollout-audit].each do |target|
   errors << "missing #{target} target in Makefile" unless makefile.match?(/^#{Regexp.escape(target)}:/)
 end
 
@@ -88,15 +87,10 @@ required_prompts = %w[
   official-docs.md
   site-workflow.md
   preserve-existing-post.md
+  orchestrator-site-workflow.md
+  orchestrator-editorial-workflow.md
+  orchestrator-preserve-existing-post.md
 ]
-
-if phase_num >= 3 || File.file?(File.join(repo_root, ".codex", "prompts", "orchestrator-site-workflow.md"))
-  required_prompts += %w[
-    orchestrator-site-workflow.md
-    orchestrator-editorial-workflow.md
-    orchestrator-preserve-existing-post.md
-  ]
-end
 
 required_prompts.each do |prompt|
   prompt_path = File.join(prompt_dir, prompt)
@@ -109,24 +103,11 @@ if File.file?(codex_usage_path) && File.file?(docs_readme_path)
   codex_usage = File.read(codex_usage_path)
   docs_readme = File.read(docs_readme_path)
 
-  use_orchestrator_starters =
-    phase_num >= 4 ||
-      (codex_usage.include?("@.codex/prompts/orchestrator-site-workflow.md") &&
-       docs_readme.include?("@.codex/prompts/orchestrator-site-workflow.md"))
-
-  starter_needles =
-    if use_orchestrator_starters
-      [
-        "@.codex/prompts/orchestrator-site-workflow.md",
-        "@.codex/prompts/orchestrator-editorial-workflow.md",
-        "@.codex/prompts/orchestrator-preserve-existing-post.md"
-      ]
-    else
-      [
-        "@.codex/prompts/site-workflow.md",
-        "@.codex/prompts/editorial-workflow.md"
-      ]
-    end
+  starter_needles = [
+    "@.codex/prompts/orchestrator-site-workflow.md",
+    "@.codex/prompts/orchestrator-editorial-workflow.md",
+    "@.codex/prompts/orchestrator-preserve-existing-post.md"
+  ]
 
   starter_needles.each do |needle|
     errors << "missing #{needle} in .codex/docs/codex-usage.md" unless codex_usage.include?(needle)
@@ -135,7 +116,7 @@ if File.file?(codex_usage_path) && File.file?(docs_readme_path)
 end
 
 medium_skill_exists = Dir.exist?(File.join(repo_root, ".agents", "skills", "medium-porter"))
-if phase_num >= 5 || !medium_skill_exists
+if !medium_skill_exists
   retired_tokens = [
     /medium-porter/i,
     /medium-to-blog/i,
@@ -159,6 +140,42 @@ if phase_num >= 5 || !medium_skill_exists
   end
 end
 
+common_ancestor = `git -C "#{repo_root}" merge-base main HEAD 2>/dev/null`.strip
+changed = Set.new
+if !common_ancestor.empty?
+  `git -C "#{repo_root}" diff --name-only --diff-filter=ACMRD #{common_ancestor}...HEAD`.each_line do |line|
+    value = line.strip
+    changed << value unless value.empty?
+  end
+end
+`git -C "#{repo_root}" diff --name-only --diff-filter=ACMRD`.each_line do |line|
+  value = line.strip
+  changed << value unless value.empty?
+end
+`git -C "#{repo_root}" diff --name-only --cached --diff-filter=ACMRD`.each_line do |line|
+  value = line.strip
+  changed << value unless value.empty?
+end
+`git -C "#{repo_root}" ls-files --others --exclude-standard`.each_line do |line|
+  value = line.strip
+  changed << value unless value.empty?
+end
+
+governance_change = changed.any? do |path|
+  path.match?(%r{\Ascripts/(validate-rollout-governance\.rb|validate-phase-scope\.sh|create-pr\.sh|finalize-merge\.sh|start-phase\.sh|rollout-audit\.sh|run-codex-checks\.sh)\z}) ||
+    path == ".github/workflows/rollout-governance.yml"
+end
+
+test_or_evidence_change = changed.any? do |path|
+  path.start_with?("scripts/tests/") ||
+    path == "scripts/run-rollout-governance-tests.sh" ||
+    path.start_with?(".codex/rollout/evidence/")
+end
+
+if governance_change && !test_or_evidence_change
+  errors << "governance script changes require matching test/evidence updates (scripts/tests/* and .codex/rollout/evidence/*)"
+end
+
 if errors.empty?
   puts "codex workflow checks passed"
   puts "validated skills: #{skill_paths.length}"
@@ -169,4 +186,5 @@ end
 RUBY
 
 "$repo_root/scripts/validate-multi-agent-contracts.rb"
-"$repo_root/scripts/validate-phase-scope.sh"
+"$repo_root/scripts/run-rollout-governance-tests.sh"
+ruby "$repo_root/scripts/validate-rollout-governance.rb"

--- a/scripts/run-rollout-governance-tests.sh
+++ b/scripts/run-rollout-governance-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+ruby "$repo_root/scripts/tests/rollout_governance_test.rb"

--- a/scripts/start-phase.sh
+++ b/scripts/start-phase.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+plan="${PLAN:-${1:-}}"
+phase="${PHASE:-${2:-}}"
+topic="${TOPIC:-${3:-}}"
+type="${TYPE:-${4:-chore}}"
+
+if [[ -z "$phase" ]]; then
+  echo "error: provide PHASE or pass it as the second argument" >&2
+  exit 1
+fi
+
+if [[ -z "$topic" ]]; then
+  echo "error: provide TOPIC or pass it as the third argument" >&2
+  exit 1
+fi
+
+if ! [[ "$phase" =~ ^[0-9]+$ ]] || [[ "$phase" -lt 1 ]]; then
+  echo "error: PHASE must be a positive integer" >&2
+  exit 1
+fi
+
+active_plan_path="$repo_root/.codex/rollout/active-plan.yaml"
+if [[ ! -f "$active_plan_path" ]]; then
+  echo "error: missing active rollout plan at .codex/rollout/active-plan.yaml" >&2
+  exit 1
+fi
+
+active_info="$(
+  ruby - "$active_plan_path" <<'RUBY'
+require "yaml"
+
+path = ARGV.fetch(0)
+data = YAML.safe_load(File.read(path), permitted_classes: [Date, Time], aliases: false) || {}
+plan_id = data["plan_id"].to_s.strip
+base_branch = data["base_branch"].to_s.strip
+branch_pattern = data["branch_pattern"].to_s.strip
+
+if plan_id.empty? || base_branch.empty? || branch_pattern.empty?
+  warn "error: active rollout plan missing required keys (plan_id/base_branch/branch_pattern)"
+  exit 1
+end
+
+puts "#{plan_id}\t#{base_branch}\t#{branch_pattern}"
+RUBY
+)"
+
+active_plan_id="$(printf '%s' "$active_info" | awk -F '\t' 'NR==1 {print $1}')"
+base_branch="$(printf '%s' "$active_info" | awk -F '\t' 'NR==1 {print $2}')"
+branch_pattern="$(printf '%s' "$active_info" | awk -F '\t' 'NR==1 {print $3}')"
+
+if [[ -z "$plan" ]]; then
+  plan="$active_plan_id"
+elif [[ "$plan" != "$active_plan_id" ]]; then
+  echo "error: PLAN=$plan does not match active plan_id=$active_plan_id" >&2
+  exit 1
+fi
+
+manifest="$repo_root/.codex/rollout/plans/$plan/phase-$phase.txt"
+if [[ ! -f "$manifest" ]]; then
+  echo "error: missing phase manifest .codex/rollout/plans/$plan/phase-$phase.txt" >&2
+  exit 1
+fi
+
+current_branch="$(git branch --show-current)"
+if [[ "$current_branch" != "$base_branch" ]]; then
+  echo "error: start-phase must run from $base_branch; current branch is $current_branch" >&2
+  exit 1
+fi
+
+"$repo_root/.agents/skills/repo-flow/scripts/ensure-clean-tree.sh"
+
+main_remote="origin"
+main_remote_branch="$base_branch"
+if upstream_ref="$(git rev-parse --abbrev-ref --symbolic-full-name "${base_branch}@{upstream}" 2>/dev/null)"; then
+  main_remote="${upstream_ref%%/*}"
+  main_remote_branch="${upstream_ref#*/}"
+fi
+
+if ! git remote get-url "$main_remote" >/dev/null 2>&1; then
+  echo "error: remote $main_remote is not configured for local $base_branch" >&2
+  exit 1
+fi
+
+if ! git fetch "$main_remote" "$main_remote_branch" --quiet; then
+  echo "error: failed to fetch $main_remote/$main_remote_branch before creating phase branch" >&2
+  exit 1
+fi
+
+git rebase "$main_remote/$main_remote_branch" >/dev/null
+
+inferred="$("$repo_root/.agents/skills/repo-flow/scripts/infer-branch-name.sh" "$type" "$topic")"
+suffix="${inferred#codex/"${type}"-}"
+branch_name="codex/phase-${phase}-${suffix}"
+
+ruby - "$branch_name" "$branch_pattern" <<'RUBY'
+branch_name = ARGV.fetch(0)
+branch_pattern = ARGV.fetch(1)
+
+match = Regexp.new(branch_pattern).match(branch_name)
+if match.nil?
+  warn "error: generated branch #{branch_name.inspect} does not match branch_pattern #{branch_pattern.inspect}"
+  exit 1
+end
+RUBY
+
+git checkout -b "$branch_name"
+
+echo "created phase branch: $branch_name"
+echo "plan: $plan"
+echo "phase: $phase"
+echo "next: implement phase scope, run make qa-local, then make create-pr TYPE=$type"

--- a/scripts/tests/rollout_governance_test.rb
+++ b/scripts/tests/rollout_governance_test.rb
@@ -70,10 +70,10 @@ class RolloutGovernanceTest < Minitest::Test
     MD
   end
 
-  def run_validator(branch: nil)
+  def run_validator(branch: nil, env: {})
     cmd = ["ruby", VALIDATOR, "--repo-root", Dir.pwd]
     cmd += ["--branch", branch] if branch
-    Open3.capture3(*cmd)
+    Open3.capture3(env, *cmd)
   end
 
   def test_dynamic_phase_count_accepts_contiguous_manifests
@@ -190,6 +190,20 @@ class RolloutGovernanceTest < Minitest::Test
       _stdout, stderr, status = run_validator
       refute status.success?
       assert_match(/broad content wildcard/i, stderr)
+    end
+  end
+
+  def test_repo_branch_has_priority_over_github_head_ref
+    with_repo(branch: "codex/phase-7-large-plan") do
+      write_active_plan
+      (1..7).each do |n|
+        write_phase(n, CORE_PLAN_PATTERNS + ["README.md"])
+      end
+      write_phase(7, CORE_PLAN_PATTERNS + ["README.md", ".codex/rollout/evidence/governance-v3/phase-7.md"])
+      write_evidence(7)
+
+      stdout, stderr, status = run_validator(env: { "GITHUB_HEAD_REF" => "codex/phase-1-unrelated" })
+      assert status.success?, "expected success, got stderr: #{stderr}\nstdout: #{stdout}"
     end
   end
 

--- a/scripts/tests/rollout_governance_test.rb
+++ b/scripts/tests/rollout_governance_test.rb
@@ -1,37 +1,31 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-
 require "fileutils"
 require "minitest/autorun"
 require "open3"
 require "tmpdir"
 require "yaml"
-
 class RolloutGovernanceTest < Minitest::Test
   VALIDATOR = File.expand_path("../validate-rollout-governance.rb", __dir__)
   CORE_PLAN_PATTERNS = [
     ".codex/rollout/active-plan.yaml",
     ".codex/rollout/plans/governance-v3/phase-*.txt"
   ].freeze
-
   def with_repo(branch: "codex/phase-1-test")
     Dir.mktmpdir("rollout-governance-test") do |dir|
       Dir.chdir(dir) do
         system!("git", "init")
         system!("git", "config", "user.name", "Test User")
         system!("git", "config", "user.email", "test@example.com")
-
         FileUtils.mkdir_p(".codex/rollout/plans/governance-v3")
         File.write("README.md", "baseline\n")
         system!("git", "add", "README.md")
         system!("git", "commit", "-m", "baseline")
         system!("git", "checkout", "-b", branch)
-
         yield dir
       end
     end
   end
-
   def write_active_plan(overrides = {})
     plan = {
       "version" => 1,
@@ -47,35 +41,29 @@ class RolloutGovernanceTest < Minitest::Test
       },
       "required_checks" => ["build", "semgrep", "rollout-governance"]
     }
-
     deep_merge!(plan, overrides)
     File.write(".codex/rollout/active-plan.yaml", plan.to_yaml)
   end
-
   def write_phase(number, lines)
     path = ".codex/rollout/plans/governance-v3/phase-#{number}.txt"
     body = lines.join("\n")
     File.write(path, "#{body}\n")
   end
-
   def write_evidence(phase = 1)
     path = ".codex/rollout/evidence/governance-v3/phase-#{phase}.md"
     FileUtils.mkdir_p(File.dirname(path))
     File.write(path, <<~MD)
       RED
       - failing tests recorded
-
       GREEN
       - tests pass after implementation
     MD
   end
-
   def run_validator(branch: nil, env: {})
     cmd = ["ruby", VALIDATOR, "--repo-root", Dir.pwd]
     cmd += ["--branch", branch] if branch
     Open3.capture3(env, *cmd)
   end
-
   def test_dynamic_phase_count_accepts_contiguous_manifests
     with_repo(branch: "codex/phase-7-large-plan") do
       write_active_plan
@@ -84,12 +72,10 @@ class RolloutGovernanceTest < Minitest::Test
       end
       write_phase(7, CORE_PLAN_PATTERNS + ["README.md", ".codex/rollout/evidence/governance-v3/phase-7.md"])
       write_evidence(7)
-
-      stdout, stderr, status = run_validator
+      stdout, stderr, status = run_validator(env: { "GITHUB_HEAD_REF" => "codex/phase-1-unrelated" })
       assert status.success?, "expected success, got stderr: #{stderr}\nstdout: #{stdout}"
     end
   end
-
   def test_missing_intermediate_phase_manifest_fails
     with_repo(branch: "codex/phase-4-gap-case") do
       write_active_plan
@@ -97,13 +83,11 @@ class RolloutGovernanceTest < Minitest::Test
       write_phase(2, ["README.md"])
       write_phase(4, ["README.md"])
       write_evidence(4)
-
       _stdout, stderr, status = run_validator
       refute status.success?
       assert_match(/missing phase manifest/i, stderr)
     end
   end
-
   def test_ignored_content_paths_are_excluded_from_size_caps_only
     with_repo do
       write_active_plan(
@@ -121,17 +105,14 @@ class RolloutGovernanceTest < Minitest::Test
         ]
       )
       write_evidence(1)
-
       FileUtils.mkdir_p("scripts")
       File.write("scripts/demo.sh", "#!/usr/bin/env bash\necho hi\n")
       FileUtils.mkdir_p("_posts")
       File.write("_posts/2026-03-14-long-post.md", ("x\n" * 5000))
-
       stdout, stderr, status = run_validator
       assert status.success?, "expected success, got stderr: #{stderr}\nstdout: #{stdout}"
     end
   end
-
   def test_non_content_size_cap_failure
     with_repo do
       write_active_plan(
@@ -148,16 +129,13 @@ class RolloutGovernanceTest < Minitest::Test
         ]
       )
       write_evidence(1)
-
       FileUtils.mkdir_p("scripts")
       File.write("scripts/demo.sh", ("line\n" * 50))
-
       _stdout, stderr, status = run_validator
       refute status.success?
       assert_match(/changed lines exceed/i, stderr)
     end
   end
-
   def test_scope_failure_even_for_ignored_paths
     with_repo do
       write_active_plan
@@ -169,16 +147,13 @@ class RolloutGovernanceTest < Minitest::Test
         ]
       )
       write_evidence(1)
-
       FileUtils.mkdir_p("_posts")
       File.write("_posts/2026-03-14-long-post.md", "hello\n")
-
       _stdout, stderr, status = run_validator
       refute status.success?
       assert_match(/outside phase-1 scope/i, stderr)
     end
   end
-
   def test_broad_content_wildcard_in_manifest_is_blocked
     with_repo do
       write_active_plan
@@ -186,29 +161,12 @@ class RolloutGovernanceTest < Minitest::Test
       write_evidence(1)
       FileUtils.mkdir_p("_posts")
       File.write("_posts/2026-03-14-long-post.md", "hello\n")
-
       _stdout, stderr, status = run_validator
       refute status.success?
       assert_match(/broad content wildcard/i, stderr)
     end
   end
-
-  def test_repo_branch_has_priority_over_github_head_ref
-    with_repo(branch: "codex/phase-7-large-plan") do
-      write_active_plan
-      (1..7).each do |n|
-        write_phase(n, CORE_PLAN_PATTERNS + ["README.md"])
-      end
-      write_phase(7, CORE_PLAN_PATTERNS + ["README.md", ".codex/rollout/evidence/governance-v3/phase-7.md"])
-      write_evidence(7)
-
-      stdout, stderr, status = run_validator(env: { "GITHUB_HEAD_REF" => "codex/phase-1-unrelated" })
-      assert status.success?, "expected success, got stderr: #{stderr}\nstdout: #{stdout}"
-    end
-  end
-
   private
-
   def deep_merge!(target, updates)
     updates.each_pair do |key, value|
       if target[key].is_a?(Hash) && value.is_a?(Hash)
@@ -218,11 +176,9 @@ class RolloutGovernanceTest < Minitest::Test
       end
     end
   end
-
   def system!(*args)
     ok = system(*args)
     return if ok
-
     raise "command failed: #{args.join(' ')}"
   end
 end

--- a/scripts/tests/rollout_governance_test.rb
+++ b/scripts/tests/rollout_governance_test.rb
@@ -1,0 +1,214 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "minitest/autorun"
+require "open3"
+require "tmpdir"
+require "yaml"
+
+class RolloutGovernanceTest < Minitest::Test
+  VALIDATOR = File.expand_path("../validate-rollout-governance.rb", __dir__)
+  CORE_PLAN_PATTERNS = [
+    ".codex/rollout/active-plan.yaml",
+    ".codex/rollout/plans/governance-v3/phase-*.txt"
+  ].freeze
+
+  def with_repo(branch: "codex/phase-1-test")
+    Dir.mktmpdir("rollout-governance-test") do |dir|
+      Dir.chdir(dir) do
+        system!("git", "init")
+        system!("git", "config", "user.name", "Test User")
+        system!("git", "config", "user.email", "test@example.com")
+
+        FileUtils.mkdir_p(".codex/rollout/plans/governance-v3")
+        File.write("README.md", "baseline\n")
+        system!("git", "add", "README.md")
+        system!("git", "commit", "-m", "baseline")
+        system!("git", "checkout", "-b", branch)
+
+        yield dir
+      end
+    end
+  end
+
+  def write_active_plan(overrides = {})
+    plan = {
+      "version" => 1,
+      "plan_id" => "governance-v3",
+      "apply_to_all_prs" => true,
+      "mode" => "sequential",
+      "base_branch" => "main",
+      "branch_pattern" => "^codex/phase-(\\d+)-[a-z0-9-]+$",
+      "limits" => {
+        "max_changed_files_non_content" => 25,
+        "max_changed_lines_non_content" => 1200,
+        "ignore_paths_for_size_caps" => ["_posts/**", "_pages/**", "_drafts/**"]
+      },
+      "required_checks" => ["build", "semgrep", "rollout-governance"]
+    }
+
+    deep_merge!(plan, overrides)
+    File.write(".codex/rollout/active-plan.yaml", plan.to_yaml)
+  end
+
+  def write_phase(number, lines)
+    path = ".codex/rollout/plans/governance-v3/phase-#{number}.txt"
+    body = lines.join("\n")
+    File.write(path, "#{body}\n")
+  end
+
+  def write_evidence(phase = 1)
+    path = ".codex/rollout/evidence/governance-v3/phase-#{phase}.md"
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, <<~MD)
+      RED
+      - failing tests recorded
+
+      GREEN
+      - tests pass after implementation
+    MD
+  end
+
+  def run_validator(branch: nil)
+    cmd = ["ruby", VALIDATOR, "--repo-root", Dir.pwd]
+    cmd += ["--branch", branch] if branch
+    Open3.capture3(*cmd)
+  end
+
+  def test_dynamic_phase_count_accepts_contiguous_manifests
+    with_repo(branch: "codex/phase-7-large-plan") do
+      write_active_plan
+      (1..7).each do |n|
+        write_phase(n, CORE_PLAN_PATTERNS + ["README.md"])
+      end
+      write_phase(7, CORE_PLAN_PATTERNS + ["README.md", ".codex/rollout/evidence/governance-v3/phase-7.md"])
+      write_evidence(7)
+
+      stdout, stderr, status = run_validator
+      assert status.success?, "expected success, got stderr: #{stderr}\nstdout: #{stdout}"
+    end
+  end
+
+  def test_missing_intermediate_phase_manifest_fails
+    with_repo(branch: "codex/phase-4-gap-case") do
+      write_active_plan
+      write_phase(1, ["README.md"])
+      write_phase(2, ["README.md"])
+      write_phase(4, ["README.md"])
+      write_evidence(4)
+
+      _stdout, stderr, status = run_validator
+      refute status.success?
+      assert_match(/missing phase manifest/i, stderr)
+    end
+  end
+
+  def test_ignored_content_paths_are_excluded_from_size_caps_only
+    with_repo do
+      write_active_plan(
+        "limits" => {
+          "max_changed_files_non_content" => 10,
+          "max_changed_lines_non_content" => 200
+        }
+      )
+      write_phase(
+        1,
+        CORE_PLAN_PATTERNS + [
+          ".codex/rollout/evidence/governance-v3/phase-1.md",
+          "scripts/demo.sh",
+          "_posts/2026-03-14-long-post.md"
+        ]
+      )
+      write_evidence(1)
+
+      FileUtils.mkdir_p("scripts")
+      File.write("scripts/demo.sh", "#!/usr/bin/env bash\necho hi\n")
+      FileUtils.mkdir_p("_posts")
+      File.write("_posts/2026-03-14-long-post.md", ("x\n" * 5000))
+
+      stdout, stderr, status = run_validator
+      assert status.success?, "expected success, got stderr: #{stderr}\nstdout: #{stdout}"
+    end
+  end
+
+  def test_non_content_size_cap_failure
+    with_repo do
+      write_active_plan(
+        "limits" => {
+          "max_changed_files_non_content" => 10,
+          "max_changed_lines_non_content" => 10
+        }
+      )
+      write_phase(
+        1,
+        CORE_PLAN_PATTERNS + [
+          ".codex/rollout/evidence/governance-v3/phase-1.md",
+          "scripts/demo.sh"
+        ]
+      )
+      write_evidence(1)
+
+      FileUtils.mkdir_p("scripts")
+      File.write("scripts/demo.sh", ("line\n" * 50))
+
+      _stdout, stderr, status = run_validator
+      refute status.success?
+      assert_match(/changed lines exceed/i, stderr)
+    end
+  end
+
+  def test_scope_failure_even_for_ignored_paths
+    with_repo do
+      write_active_plan
+      write_phase(
+        1,
+        CORE_PLAN_PATTERNS + [
+          ".codex/rollout/evidence/governance-v3/phase-1.md",
+          "scripts/demo.sh"
+        ]
+      )
+      write_evidence(1)
+
+      FileUtils.mkdir_p("_posts")
+      File.write("_posts/2026-03-14-long-post.md", "hello\n")
+
+      _stdout, stderr, status = run_validator
+      refute status.success?
+      assert_match(/outside phase-1 scope/i, stderr)
+    end
+  end
+
+  def test_broad_content_wildcard_in_manifest_is_blocked
+    with_repo do
+      write_active_plan
+      write_phase(1, CORE_PLAN_PATTERNS + [".codex/rollout/evidence/governance-v3/phase-1.md", "_posts/*"])
+      write_evidence(1)
+      FileUtils.mkdir_p("_posts")
+      File.write("_posts/2026-03-14-long-post.md", "hello\n")
+
+      _stdout, stderr, status = run_validator
+      refute status.success?
+      assert_match(/broad content wildcard/i, stderr)
+    end
+  end
+
+  private
+
+  def deep_merge!(target, updates)
+    updates.each_pair do |key, value|
+      if target[key].is_a?(Hash) && value.is_a?(Hash)
+        deep_merge!(target[key], value)
+      else
+        target[key] = value
+      end
+    end
+  end
+
+  def system!(*args)
+    ok = system(*args)
+    return if ok
+
+    raise "command failed: #{args.join(' ')}"
+  end
+end

--- a/scripts/validate-rollout-governance.rb
+++ b/scripts/validate-rollout-governance.rb
@@ -124,10 +124,13 @@ errors << "active-plan.yaml limits.max_changed_files_non_content must be a posit
 errors << "active-plan.yaml limits.max_changed_lines_non_content must be a positive integer" unless max_changed_lines_non_content.is_a?(Integer) && max_changed_lines_non_content.positive?
 errors << "active-plan.yaml limits.ignore_paths_for_size_caps must be a non-empty list" if ignore_paths_for_size_caps.empty?
 
-branch = options[:branch] || ENV["ROLLOUT_BRANCH"] || ENV["GITHUB_HEAD_REF"]
+branch = options[:branch] || ENV["ROLLOUT_BRANCH"]
 if branch.to_s.strip.empty?
   ok, branch_output = command_output(repo_root, "branch --show-current")
   branch = ok ? branch_output.strip : ""
+end
+if branch.to_s.strip.empty?
+  branch = ENV["GITHUB_HEAD_REF"] || ENV["GITHUB_REF_NAME"] || ""
 end
 
 phase = nil

--- a/scripts/validate-rollout-governance.rb
+++ b/scripts/validate-rollout-governance.rb
@@ -124,7 +124,7 @@ errors << "active-plan.yaml limits.max_changed_files_non_content must be a posit
 errors << "active-plan.yaml limits.max_changed_lines_non_content must be a positive integer" unless max_changed_lines_non_content.is_a?(Integer) && max_changed_lines_non_content.positive?
 errors << "active-plan.yaml limits.ignore_paths_for_size_caps must be a non-empty list" if ignore_paths_for_size_caps.empty?
 
-branch = options[:branch] || ENV["ROLLOUT_BRANCH"]
+branch = options[:branch] || ENV["ROLLOUT_BRANCH"] || ENV["GITHUB_HEAD_REF"]
 if branch.to_s.strip.empty?
   ok, branch_output = command_output(repo_root, "branch --show-current")
   branch = ok ? branch_output.strip : ""

--- a/scripts/validate-rollout-governance.rb
+++ b/scripts/validate-rollout-governance.rb
@@ -1,0 +1,250 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "date"
+require "optparse"
+require "set"
+require "yaml"
+
+options = {
+  repo_root: File.expand_path("..", __dir__)
+}
+
+OptionParser.new do |parser|
+  parser.on("--repo-root PATH", "Repository root path") do |value|
+    options[:repo_root] = File.expand_path(value)
+  end
+  parser.on("--branch NAME", "Branch name override") do |value|
+    options[:branch] = value
+  end
+end.parse!(ARGV)
+
+repo_root = options[:repo_root]
+errors = []
+
+def command_output(repo_root, command)
+  output = `git -C "#{repo_root}" #{command} 2>/dev/null`
+  [($? && $?.success?), output]
+end
+
+def changed_files(repo_root, base_branch)
+  files = Set.new
+  untracked_files = Set.new
+
+  merge_base_ok, merge_base = command_output(repo_root, "merge-base #{base_branch} HEAD")
+  merge_base = merge_base.strip
+
+  if merge_base_ok && !merge_base.empty?
+    _, committed = command_output(repo_root, "diff --name-only --diff-filter=ACMRD #{merge_base}...HEAD")
+    committed.each_line { |line| files << line.strip unless line.strip.empty? }
+  end
+
+  _, working = command_output(repo_root, "diff --name-only --diff-filter=ACMRD")
+  working.each_line { |line| files << line.strip unless line.strip.empty? }
+
+  _, staged = command_output(repo_root, "diff --name-only --cached --diff-filter=ACMRD")
+  staged.each_line { |line| files << line.strip unless line.strip.empty? }
+
+  _, untracked = command_output(repo_root, "ls-files --others --exclude-standard")
+  untracked.each_line do |line|
+    value = line.strip
+    next if value.empty?
+
+    files << value
+    untracked_files << value
+  end
+
+  [files.to_a.sort, merge_base, untracked_files.to_a.sort]
+end
+
+def add_numstat(output, line_counts)
+  output.each_line do |line|
+    added, deleted, file = line.strip.split("\t", 3)
+    next if file.to_s.empty?
+
+    next if added == "-" || deleted == "-"
+
+    total = added.to_i + deleted.to_i
+    line_counts[file] = [line_counts[file], total].max
+  end
+end
+
+def changed_line_counts(repo_root, base_branch, merge_base, untracked_files)
+  counts = Hash.new(0)
+
+  if !merge_base.empty?
+    _, committed = command_output(repo_root, "diff --numstat --diff-filter=ACMRD #{merge_base}...HEAD")
+    add_numstat(committed, counts)
+  end
+
+  _, working = command_output(repo_root, "diff --numstat --diff-filter=ACMRD")
+  add_numstat(working, counts)
+
+  _, staged = command_output(repo_root, "diff --numstat --cached --diff-filter=ACMRD")
+  add_numstat(staged, counts)
+
+  untracked_files.each do |file|
+    next unless File.file?(File.join(repo_root, file))
+
+    line_count = File.foreach(File.join(repo_root, file)).count
+    counts[file] = [counts[file], line_count].max
+  end
+
+  counts
+end
+
+def glob_match?(pattern, value)
+  File.fnmatch?(pattern, value, File::FNM_PATHNAME | File::FNM_DOTMATCH | File::FNM_EXTGLOB)
+end
+
+active_plan_path = File.join(repo_root, ".codex", "rollout", "active-plan.yaml")
+unless File.file?(active_plan_path)
+  warn "error: missing active rollout plan #{active_plan_path.delete_prefix("#{repo_root}/")}"
+  exit 1
+end
+
+plan = YAML.safe_load(File.read(active_plan_path), permitted_classes: [Date, Time], aliases: false) || {}
+
+plan_id = plan["plan_id"].to_s.strip
+apply_to_all_prs = plan["apply_to_all_prs"] == true
+mode = plan["mode"].to_s.strip
+base_branch = plan["base_branch"].to_s.strip
+branch_pattern = plan["branch_pattern"].to_s.strip
+limits = plan["limits"].is_a?(Hash) ? plan["limits"] : {}
+max_changed_files_non_content = limits["max_changed_files_non_content"]
+max_changed_lines_non_content = limits["max_changed_lines_non_content"]
+ignore_paths_for_size_caps = limits["ignore_paths_for_size_caps"].is_a?(Array) ? limits["ignore_paths_for_size_caps"] : []
+
+errors << "active-plan.yaml missing plan_id" if plan_id.empty?
+errors << "active-plan.yaml must set apply_to_all_prs=true" unless apply_to_all_prs
+errors << "active-plan.yaml mode must be sequential" unless mode == "sequential"
+errors << "active-plan.yaml missing base_branch" if base_branch.empty?
+errors << "active-plan.yaml missing branch_pattern" if branch_pattern.empty?
+errors << "active-plan.yaml limits.max_changed_files_non_content must be a positive integer" unless max_changed_files_non_content.is_a?(Integer) && max_changed_files_non_content.positive?
+errors << "active-plan.yaml limits.max_changed_lines_non_content must be a positive integer" unless max_changed_lines_non_content.is_a?(Integer) && max_changed_lines_non_content.positive?
+errors << "active-plan.yaml limits.ignore_paths_for_size_caps must be a non-empty list" if ignore_paths_for_size_caps.empty?
+
+branch = options[:branch] || ENV["ROLLOUT_BRANCH"]
+if branch.to_s.strip.empty?
+  ok, branch_output = command_output(repo_root, "branch --show-current")
+  branch = ok ? branch_output.strip : ""
+end
+
+phase = nil
+if branch == base_branch
+  puts "rollout governance check skipped for base branch #{base_branch}"
+  exit 0 if errors.empty?
+elsif branch.empty?
+  errors << "unable to detect current branch"
+else
+  match = Regexp.new(branch_pattern).match(branch) rescue nil
+  if match.nil?
+    errors << "branch #{branch.inspect} does not match required phase pattern #{branch_pattern.inspect}" if apply_to_all_prs
+  else
+    phase = match[1].to_i
+    errors << "phase extracted from branch must be >= 1" if phase <= 0
+  end
+end
+
+plan_dir = File.join(repo_root, ".codex", "rollout", "plans", plan_id)
+phase_files = Dir[File.join(plan_dir, "phase-*.txt")]
+phase_numbers = phase_files.filter_map do |path|
+  match = path.match(/phase-(\d+)\.txt$/)
+  match && match[1].to_i
+end.sort
+
+if phase_numbers.empty?
+  errors << "no phase manifests found under #{plan_dir.delete_prefix("#{repo_root}/")}"
+else
+  highest = phase_numbers.max
+  (1..highest).each do |number|
+    manifest = File.join(plan_dir, "phase-#{number}.txt")
+    errors << "missing phase manifest #{manifest.delete_prefix("#{repo_root}/")}" unless File.file?(manifest)
+  end
+end
+
+if phase && !phase_numbers.empty?
+  highest = phase_numbers.max
+  if phase > highest
+    errors << "branch phase #{phase} exceeds highest configured phase #{highest}"
+  end
+end
+
+if errors.any?
+  errors.each { |error| warn "error: #{error}" }
+  exit 1
+end
+
+manifest_path = File.join(plan_dir, "phase-#{phase}.txt")
+unless File.file?(manifest_path)
+  warn "error: missing phase manifest #{manifest_path.delete_prefix("#{repo_root}/")}"
+  exit 1
+end
+
+manifest_patterns = File.readlines(manifest_path, chomp: true).map(&:strip).reject { |line| line.empty? || line.start_with?("#") }
+if manifest_patterns.empty?
+  warn "error: no file patterns declared in #{manifest_path.delete_prefix("#{repo_root}/")}"
+  exit 1
+end
+
+content_roots = ignore_paths_for_size_caps.filter_map do |pattern|
+  match = pattern.to_s.match(%r{\A(_posts|_pages|_drafts)/\*\*\z})
+  match && "#{match[1]}/"
+end.uniq
+
+manifest_patterns.each do |pattern|
+  content_roots.each do |root|
+    if pattern.start_with?("#{root}*")
+      warn "error: broad content wildcard #{pattern.inspect} is not allowed in #{manifest_path.delete_prefix("#{repo_root}/")}"
+      exit 1
+    end
+  end
+end
+
+evidence_path = File.join(repo_root, ".codex", "rollout", "evidence", plan_id, "phase-#{phase}.md")
+unless File.file?(evidence_path)
+  warn "error: missing TDD evidence file #{evidence_path.delete_prefix("#{repo_root}/")}"
+  exit 1
+end
+
+evidence = File.read(evidence_path)
+unless evidence.match?(/^\s*RED\b/i) && evidence.match?(/^\s*GREEN\b/i)
+  warn "error: TDD evidence file must include RED and GREEN sections (#{evidence_path.delete_prefix("#{repo_root}/")})"
+  exit 1
+end
+
+changed, merge_base, untracked_files = changed_files(repo_root, base_branch)
+if changed.empty?
+  puts "rollout governance check passed (no changed files)"
+  exit 0
+end
+
+scope_violations = changed.reject do |file|
+  manifest_patterns.any? { |pattern| glob_match?(pattern, file) }
+end
+
+if scope_violations.any?
+  warn "error: files outside phase-#{phase} scope:"
+  scope_violations.each { |path| warn "  - #{path}" }
+  exit 1
+end
+
+line_counts = changed_line_counts(repo_root, base_branch, merge_base, untracked_files)
+non_content = changed.reject do |path|
+  ignore_paths_for_size_caps.any? { |pattern| glob_match?(pattern, path) }
+end
+
+non_content_changed_files = non_content.length
+non_content_changed_lines = non_content.sum { |path| line_counts[path].to_i }
+
+if non_content_changed_files > max_changed_files_non_content
+  warn "error: changed files exceed limit (#{non_content_changed_files} > #{max_changed_files_non_content}) for non-content paths"
+  exit 1
+end
+
+if non_content_changed_lines > max_changed_lines_non_content
+  warn "error: changed lines exceed limit (#{non_content_changed_lines} > #{max_changed_lines_non_content}) for non-content paths"
+  exit 1
+end
+
+puts "rollout governance check passed for plan=#{plan_id} phase=#{phase}"


### PR DESCRIPTION
## Summary

- phase 1 rollout governance v3 foundation

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Rollout Metadata

- plan_id: `governance-v3`
- phase: `1`
- required_checks: `build,semgrep,rollout-governance`

## Validation

- `make qa-local`

## Affected Files

```text
.codex/rollout/active-plan.yaml
.codex/rollout/evidence/governance-v3/phase-1.md
.codex/rollout/plans/governance-v3/phase-1.txt
.codex/rollout/plans/multi-agent-v1/phase-1.txt
.codex/rollout/plans/multi-agent-v1/phase-2.txt
.codex/rollout/plans/multi-agent-v1/phase-3.txt
.codex/rollout/plans/multi-agent-v1/phase-4.txt
.codex/rollout/plans/multi-agent-v1/phase-5.txt
.codex/rollout/plans/multi-agent-v1/phase-6.txt
.github/workflows/rollout-governance.yml
Makefile
scripts/create-pr.sh
scripts/finalize-merge.sh
scripts/rollout-audit.sh
scripts/run-codex-checks.sh
scripts/run-rollout-governance-tests.sh
scripts/start-phase.sh
scripts/tests/rollout_governance_test.rb
scripts/validate-rollout-governance.rb
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
