### PR TITLE
feat: phase 1 auto delete published drafts

### DIFF
--- a/.codex/rollout/evidence/governance-v3/phase-1.md
+++ b/.codex/rollout/evidence/governance-v3/phase-1.md
@@ -12,3 +12,10 @@ GREEN
 - result: passed
 - representative output:
   - `6 runs, 14 assertions, 0 failures, 0 errors, 0 skips`
+
+GREEN (publish workflow expansion)
+
+- command: `make qa-local`
+- result: passed after phase-1 manifest scope was updated for publish workflow paths
+- representative output:
+  - `codex workflow checks passed`

--- a/.codex/rollout/plans/governance-v3/phase-1.txt
+++ b/.codex/rollout/plans/governance-v3/phase-1.txt
@@ -10,6 +10,11 @@ scripts/create-pr.sh
 scripts/finalize-merge.sh
 scripts/start-phase.sh
 scripts/rollout-audit.sh
+scripts/publish-draft.sh
+scripts/run-publish-draft-tests.sh
 scripts/tests/*
+scripts/lib/publish_draft.rb
+scripts/lib/publish_draft_core.rb
 .github/workflows/rollout-governance.yml
 Makefile
+README.md

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: help setup hooks-install lint security codex-check site-audit qa-local validate-draft qa-publish publish-draft start-work start-phase check create-pr finalize-merge rollout-audit rollout-tests skill-audit skill-vendor
+.PHONY: help setup hooks-install lint security codex-check site-audit qa-local validate-draft qa-publish publish-draft publish-draft-tests start-work start-phase check create-pr finalize-merge rollout-audit rollout-tests skill-audit skill-vendor
 
 ifneq (,$(filter skill-audit skill-vendor,$(firstword $(MAKECMDGOALS))))
 SKILL_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -17,7 +17,8 @@ help:
 	@echo "Editorial:"
 	@echo "  make validate-draft PATH=_drafts/post.md"
 	@echo "  make qa-publish PATH=_drafts/post.md"
-	@echo "  make publish-draft PATH=_drafts/post.md DATE=YYYY-MM-DD"
+	@echo "  make publish-draft PATH=_drafts/post.md DATE=YYYY-MM-DD [KEEP_DRAFT=1]"
+	@echo "  make publish-draft-tests"
 	@echo ""
 	@echo "Site Quality:"
 	@echo "  make site-audit AUDIT=seo TARGET=site"
@@ -71,7 +72,10 @@ qa-publish:
 	@/usr/bin/env DRAFT_PATH='$(PATH)' /bin/bash -lc './scripts/qa-publish.sh "$$DRAFT_PATH"'
 
 publish-draft:
-	@/usr/bin/env DRAFT_PATH='$(PATH)' DATE='$(DATE)' SLUG='$(SLUG)' /bin/bash -lc './scripts/publish-draft.sh'
+	@/usr/bin/env DRAFT_PATH='$(PATH)' DATE='$(DATE)' SLUG='$(SLUG)' KEEP_DRAFT='$(KEEP_DRAFT)' /bin/bash -lc './scripts/publish-draft.sh'
+
+publish-draft-tests:
+	@./scripts/run-publish-draft-tests.sh
 
 start-work:
 	@./scripts/start-work.sh

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ make check
 ./.venv-tools/bin/pre-commit run --hook-stage pre-push --all-files
 ```
 
+## Editorial Commands
+
+```bash
+make validate-draft PATH=_drafts/post.md
+make qa-publish PATH=_drafts/post.md
+make publish-draft PATH=_drafts/post.md DATE=YYYY-MM-DD
+```
+
+`make publish-draft` now removes the source file from `_drafts/` after a successful publish.
+Use `KEEP_DRAFT=1` to opt out for one run:
+
+```bash
+make publish-draft PATH=_drafts/post.md DATE=YYYY-MM-DD KEEP_DRAFT=1
+```
+
 ## Acknowledgments
 
 This site is powered by [Jekyll](https://jekyllrb.com/) and the

--- a/scripts/lib/publish_draft.rb
+++ b/scripts/lib/publish_draft.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+coverage_output = ENV["PUBLISH_DRAFT_COVERAGE"].to_s
+unless coverage_output.empty?
+  require "coverage"
+  Coverage.start(lines: true)
+  at_exit do
+    begin
+      File.binwrite(coverage_output, Marshal.dump(Coverage.result))
+    rescue StandardError
+      # Coverage emission should never mask command exit behavior.
+    end
+  end
+end
+
+require_relative "publish_draft_core"
+
+PublishDraft.run(ARGV)

--- a/scripts/lib/publish_draft_core.rb
+++ b/scripts/lib/publish_draft_core.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "date"
+require "yaml"
+
+module PublishDraft
+  module_function
+
+  def run(argv)
+    repo_root = File.expand_path("../..", __dir__)
+    Dir.chdir(repo_root)
+
+    draft_path = ENV.fetch("DRAFT_PATH", argv[0].to_s)
+    publish_date = ENV.fetch("DATE", argv[1].to_s)
+    slug_override = ENV.fetch("SLUG", argv[2].to_s)
+    keep_draft = ENV["KEEP_DRAFT"].to_s == "1"
+
+    usage! if draft_path.empty? || publish_date.empty?
+    date_format!(publish_date)
+    draft_path_guard!(repo_root, draft_path)
+
+    run_script!(File.join(repo_root, "scripts", "qa-publish.sh"), draft_path)
+
+    target_path = create_post(repo_root, draft_path, publish_date, slug_override)
+
+    run_script!(
+      File.join(repo_root, ".agents", "skills", "jekyll-post-publisher", "scripts", "validate-post.sh"),
+      target_path,
+      { "STRICT_POST_METADATA" => "1" }
+    )
+
+    if keep_draft
+      puts "kept source draft: #{draft_path}"
+    else
+      draft_path_guard!(repo_root, draft_path)
+      File.delete(draft_path)
+      puts "deleted source draft: #{draft_path}"
+    end
+
+    puts "published draft to: #{target_path}"
+    puts "next: make qa-local"
+  end
+
+  def usage!
+    abort("usage: make publish-draft PATH=_drafts/post.md DATE=YYYY-MM-DD [KEEP_DRAFT=1]")
+  end
+
+  def date_format!(publish_date)
+    return if publish_date.match?(/^\d{4}-\d{2}-\d{2}$/)
+
+    abort("error: DATE must be in YYYY-MM-DD format")
+  end
+
+  def draft_path_guard!(repo_root, draft_path)
+    draft_root = File.join(repo_root, "_drafts")
+    expanded = File.expand_path(draft_path, repo_root)
+    return if expanded.start_with?("#{draft_root}/")
+
+    abort("error: publish-draft only supports files under _drafts/")
+  end
+
+  def run_script!(script_path, path_arg, extra_env = {})
+    success = system(extra_env, script_path, path_arg)
+    return if success
+
+    status = $?.exitstatus || 1
+    exit(status)
+  end
+
+  def create_post(repo_root, draft_path, publish_date, slug_override)
+    content = File.read(draft_path)
+    match = content.match(/\A---\s*\n(.*?)\n---\s*\n/m)
+    abort("error: missing YAML front matter in #{draft_path}") unless match
+
+    data = YAML.safe_load(match[1], permitted_classes: [Time, Date], aliases: true) || {}
+    body = content.sub(match[0], "")
+
+    slug = if !slug_override.empty?
+      slug_override
+    else
+      data.fetch("title").to_s.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "").gsub(/-+/, "-")
+    end
+    abort("error: could not derive a slug from #{draft_path}") if slug.empty?
+
+    data["date"] = publish_date
+    yaml = YAML.dump(data).sub(/\A---\s*\n/, "").sub(/\n\.\.\.\s*\z/, "")
+    expanded_draft_path = File.expand_path(draft_path, repo_root)
+    target_path = File.expand_path(File.join(File.dirname(expanded_draft_path), "..", "_posts", "#{publish_date}-#{slug}.md"))
+    abort("error: target post already exists: #{target_path}") if File.exist?(target_path)
+
+    File.write(target_path, "---\n#{yaml}---\n\n#{body}")
+    target_path
+  end
+end

--- a/scripts/run-publish-draft-tests.sh
+++ b/scripts/run-publish-draft-tests.sh
@@ -3,4 +3,5 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
-exec ruby "$repo_root/scripts/lib/publish_draft.rb" "${1:-}" "${2:-}" "${3:-}"
+
+ruby "$repo_root/scripts/tests/publish_draft_test.rb"

--- a/scripts/tests/publish_draft_test.rb
+++ b/scripts/tests/publish_draft_test.rb
@@ -1,0 +1,294 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "minitest/autorun"
+require "open3"
+require "securerandom"
+require "tmpdir"
+
+SOURCE_ROOT = File.expand_path("../..", __dir__)
+COVERAGE_DIR = Dir.mktmpdir("publish-draft-coverage")
+
+Minitest.after_run do
+  dumps = Dir.glob(File.join(COVERAGE_DIR, "*.dump"))
+  raise "missing coverage dumps for publish workflow tests" if dumps.empty?
+
+  merged = []
+  dumps.each do |dump_path|
+    result = Marshal.load(File.binread(dump_path))
+    result.each do |path, metrics|
+      next unless path.end_with?("/scripts/lib/publish_draft_core.rb")
+
+      lines = metrics.fetch(:lines)
+      lines.each_with_index do |count, idx|
+        if count.nil?
+          merged[idx] = nil if merged[idx].nil?
+        else
+          merged[idx] = 0 if merged[idx].nil?
+          merged[idx] += count
+        end
+      end
+    end
+  end
+
+  executable = merged.each_index.select { |idx| !merged[idx].nil? }
+  covered = executable.select { |idx| merged[idx].positive? }
+  uncovered = executable - covered
+
+  if executable.empty?
+    raise "missing line coverage data for scripts/lib/publish_draft_core.rb"
+  end
+  unless uncovered.empty?
+    line_list = uncovered.map { |idx| idx + 1 }.join(", ")
+    raise "publish workflow coverage is below 100%; uncovered lines: #{line_list}"
+  end
+ensure
+  FileUtils.rm_rf(COVERAGE_DIR)
+end
+
+class PublishDraftTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir("publish-draft-test")
+    @repo_root = File.join(@tmpdir, "repo")
+    FileUtils.mkdir_p(@repo_root)
+    setup_repo
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_successful_publish_deletes_draft_by_default
+    draft_path = write_draft("success-default.md", "Default Delete Draft")
+
+    stdout, stderr, status = run_publish(
+      "DRAFT_PATH" => draft_path,
+      "DATE" => "2026-03-14"
+    )
+
+    assert status.success?, "expected success, stderr: #{stderr}\nstdout: #{stdout}"
+    refute File.exist?(File.join(@repo_root, draft_path))
+    assert File.exist?(File.join(@repo_root, "_posts", "2026-03-14-default-delete-draft.md"))
+    assert_match(/deleted source draft:/, stdout)
+  end
+
+  def test_keep_draft_override_preserves_source_file
+    draft_path = write_draft("keep-draft.md", "Keep This Draft")
+
+    stdout, stderr, status = run_publish(
+      "DRAFT_PATH" => draft_path,
+      "DATE" => "2026-03-14",
+      "KEEP_DRAFT" => "1"
+    )
+
+    assert status.success?, "expected success, stderr: #{stderr}\nstdout: #{stdout}"
+    assert File.exist?(File.join(@repo_root, draft_path))
+    assert File.exist?(File.join(@repo_root, "_posts", "2026-03-14-keep-this-draft.md"))
+    assert_match(/kept source draft:/, stdout)
+  end
+
+  def test_slug_override_is_used_for_target_path
+    draft_path = write_draft("slug-override.md", "Ignored Title For Slug")
+
+    _stdout, stderr, status = run_publish(
+      "DRAFT_PATH" => draft_path,
+      "DATE" => "2026-03-14",
+      "SLUG" => "custom-slug"
+    )
+
+    assert status.success?, "expected success, stderr: #{stderr}"
+    assert File.exist?(File.join(@repo_root, "_posts", "2026-03-14-custom-slug.md"))
+  end
+
+  def test_missing_required_inputs_fails_with_usage
+    _stdout, stderr, status = run_publish("DRAFT_PATH" => "", "DATE" => "")
+
+    refute status.success?
+    assert_match(/usage: make publish-draft/, stderr)
+  end
+
+  def test_invalid_date_format_fails
+    draft_path = write_draft("bad-date.md", "Bad Date")
+
+    _stdout, stderr, status = run_publish(
+      "DRAFT_PATH" => draft_path,
+      "DATE" => "2026/03/14"
+    )
+
+    refute status.success?
+    assert_match(/DATE must be in YYYY-MM-DD format/, stderr)
+    assert File.exist?(File.join(@repo_root, draft_path))
+  end
+
+  def test_non_drafts_path_is_rejected
+    notes_dir = File.join(@repo_root, "notes")
+    FileUtils.mkdir_p(notes_dir)
+    other_path = "notes/not-a-draft.md"
+    File.write(File.join(@repo_root, other_path), "# note\n")
+
+    _stdout, stderr, status = run_publish(
+      "DRAFT_PATH" => other_path,
+      "DATE" => "2026-03-14"
+    )
+
+    refute status.success?
+    assert_match(/only supports files under _drafts\//, stderr)
+    assert File.exist?(File.join(@repo_root, other_path))
+  end
+
+  def test_qa_failure_keeps_draft_untouched
+    draft_path = write_draft("qa-failure.md", "QA Fails")
+
+    _stdout, _stderr, status = run_publish(
+      "DRAFT_PATH" => draft_path,
+      "DATE" => "2026-03-14",
+      "QA_FAIL" => "1"
+    )
+
+    refute status.success?
+    assert File.exist?(File.join(@repo_root, draft_path))
+    refute File.exist?(File.join(@repo_root, "_posts", "2026-03-14-qa-fails.md"))
+  end
+
+  def test_target_exists_failure_keeps_draft
+    draft_path = write_draft("target-exists.md", "Target Exists")
+    File.write(File.join(@repo_root, "_posts", "2026-03-14-target-exists.md"), "already here\n")
+
+    _stdout, stderr, status = run_publish(
+      "DRAFT_PATH" => draft_path,
+      "DATE" => "2026-03-14"
+    )
+
+    refute status.success?
+    assert_match(/target post already exists/, stderr)
+    assert File.exist?(File.join(@repo_root, draft_path))
+  end
+
+  def test_validate_failure_keeps_draft_and_fails
+    draft_path = write_draft("validate-fails.md", "Validate Fails")
+
+    _stdout, _stderr, status = run_publish(
+      "DRAFT_PATH" => draft_path,
+      "DATE" => "2026-03-14",
+      "VALIDATE_FAIL" => "1"
+    )
+
+    refute status.success?
+    assert File.exist?(File.join(@repo_root, draft_path))
+    assert File.exist?(File.join(@repo_root, "_posts", "2026-03-14-validate-fails.md"))
+  end
+
+  def test_missing_front_matter_fails_and_keeps_draft
+    draft_path = "_drafts/no-frontmatter.md"
+    File.write(File.join(@repo_root, draft_path), "plain text\n")
+
+    _stdout, stderr, status = run_publish(
+      "DRAFT_PATH" => draft_path,
+      "DATE" => "2026-03-14"
+    )
+
+    refute status.success?
+    assert_match(/missing YAML front matter/, stderr)
+    assert File.exist?(File.join(@repo_root, draft_path))
+  end
+
+  def test_blank_slug_from_title_is_rejected
+    draft_path = "_drafts/blank-slug.md"
+    File.write(File.join(@repo_root, draft_path), <<~MD)
+      ---
+      title: "!!!"
+      description: "A long enough description for validation checks."
+      fact_check_status: complete
+      categories: [blog]
+      ---
+
+      ## Section
+      body
+    MD
+
+    _stdout, stderr, status = run_publish(
+      "DRAFT_PATH" => draft_path,
+      "DATE" => "2026-03-14"
+    )
+
+    refute status.success?
+    assert_match(/could not derive a slug/, stderr)
+    assert File.exist?(File.join(@repo_root, draft_path))
+  end
+
+  private
+
+  def setup_repo
+    copy_source("scripts/publish-draft.sh")
+    copy_source("scripts/lib/publish_draft.rb")
+    copy_source("scripts/lib/publish_draft_core.rb")
+    write_executable(
+      "scripts/qa-publish.sh",
+      <<~SH
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [[ "${QA_FAIL:-0}" == "1" ]]; then
+          echo "error: qa failed" >&2
+          exit 1
+        fi
+      SH
+    )
+    write_executable(
+      ".agents/skills/jekyll-post-publisher/scripts/validate-post.sh",
+      <<~SH
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [[ "${VALIDATE_FAIL:-0}" == "1" ]]; then
+          echo "error: validate failed" >&2
+          exit 1
+        fi
+      SH
+    )
+    FileUtils.mkdir_p(File.join(@repo_root, "_drafts"))
+    FileUtils.mkdir_p(File.join(@repo_root, "_posts"))
+  end
+
+  def write_draft(name, title)
+    path = "_drafts/#{name}"
+    File.write(File.join(@repo_root, path), <<~MD)
+      ---
+      title: "#{title}"
+      description: "A long enough description for publish checks."
+      fact_check_status: complete
+      categories: [blog]
+      ---
+
+      ## Section
+      body
+    MD
+    path
+  end
+
+  def run_publish(env_overrides)
+    coverage_file = File.join(COVERAGE_DIR, "cov-#{SecureRandom.hex(8)}.dump")
+    env = {
+      "PUBLISH_DRAFT_COVERAGE" => coverage_file
+    }.merge(env_overrides)
+    Open3.capture3(
+      env,
+      File.join(@repo_root, "scripts/publish-draft.sh"),
+      chdir: @repo_root
+    )
+  end
+
+  def copy_source(relative_path)
+    source = File.join(SOURCE_ROOT, relative_path)
+    destination = File.join(@repo_root, relative_path)
+    FileUtils.mkdir_p(File.dirname(destination))
+    FileUtils.cp(source, destination)
+    FileUtils.chmod(0o755, destination)
+  end
+
+  def write_executable(relative_path, content)
+    destination = File.join(@repo_root, relative_path)
+    FileUtils.mkdir_p(File.dirname(destination))
+    File.write(destination, content)
+    FileUtils.chmod(0o755, destination)
+  end
+end


### PR DESCRIPTION
## Summary

- phase 1 auto delete published drafts

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Rollout Metadata

- plan_id: `governance-v3`
- phase: `1`
- required_checks: `build,semgrep,rollout-governance`

## Validation

- `make qa-local`

## Affected Files

```text
.codex/rollout/evidence/governance-v3/phase-1.md
.codex/rollout/plans/governance-v3/phase-1.txt
Makefile
README.md
scripts/lib/publish_draft.rb
scripts/lib/publish_draft_core.rb
scripts/publish-draft.sh
scripts/run-publish-draft-tests.sh
scripts/tests/publish_draft_test.rb
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
