### PR TITLE
fix: cws 16 branch policy dual mode

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,4 @@
+sandbox_mode = "workspace-write"
 [features]
 multi_agent = true
 

--- a/.codex/docs/multi-agent-red-team.md
+++ b/.codex/docs/multi-agent-red-team.md
@@ -12,8 +12,9 @@ Use this protocol on every rollout phase PR.
 
 1. Phase-skip attempt:
    open or merge `phase-n` before `phase-(n-1)`.
-2. Non-phase-branch attempt:
-   open a PR from a branch that does not match `branch_pattern`.
+2. Invalid-branch attempt:
+   open a PR from a branch that matches neither `task_branch_pattern` nor
+   `phase_branch_pattern`.
 3. Oversized non-content diff attempt:
    exceed `max_changed_lines_non_content`.
 4. Broad content-manifest attempt:
@@ -24,7 +25,8 @@ Use this protocol on every rollout phase PR.
 ## Required Outcomes
 
 - Sequencing enforcement blocks phase skipping.
-- Branch-pattern enforcement blocks non-phase PR branches.
+- Branch-pattern enforcement blocks invalid PR branches outside task and phase
+  patterns.
 - Size-cap enforcement blocks oversized non-content diffs.
 - Manifest lint blocks broad content wildcards.
 - Scope enforcement blocks out-of-manifest file changes.

--- a/.codex/docs/multi-agent-rollout-checklist.md
+++ b/.codex/docs/multi-agent-rollout-checklist.md
@@ -6,7 +6,8 @@ Use this checklist for any rollout plan driven by
 ## Plan Contract
 
 - [ ] `active-plan.yaml` exists and is valid (`version: 1`, `plan_id`, `mode: sequential`).
-- [ ] `branch_pattern` is phase-based (`^codex/phase-(\d+)-...`).
+- [ ] `task_branch_pattern` allows task branches (`^codex/cws-\d+-...`).
+- [ ] `phase_branch_pattern` remains phase-based (`^codex/phase-(\d+)-...`).
 - [ ] `required_checks` includes `build`, `semgrep`, `rollout-governance`.
 - [ ] size caps are non-content only:
   - `limits.max_changed_files_non_content`

--- a/.codex/docs/workflows.md
+++ b/.codex/docs/workflows.md
@@ -46,6 +46,7 @@ $historical-post-editor $site-quality-auditor $repo-flow
 
 - Legacy non-orchestrator prompts remain temporarily for compatibility.
 - Legacy import workflow is retired in this repository.
-- Rollout governance is phase-based and sequential (`codex/phase-<n>-...`).
+- Normal task branches use Linear-first naming (`codex/cws-<id>-...`).
+- Rollout governance remains phase-based and sequential for rollout branches (`codex/phase-<n>-...`).
 - Use `make start-phase PLAN=<plan-id> PHASE=<n> TOPIC="..." TYPE=...` for governed work.
 - Validate ruleset/check alignment with `make rollout-audit`.

--- a/.codex/rollout/active-plan.yaml
+++ b/.codex/rollout/active-plan.yaml
@@ -3,7 +3,8 @@ plan_id: governance-v3
 apply_to_all_prs: true
 mode: sequential
 base_branch: main
-branch_pattern: '^codex/phase-(\d+)-[a-z0-9-]+$'
+task_branch_pattern: '^codex/cws-\d+-[a-z0-9-]+$'
+phase_branch_pattern: '^codex/phase-(\d+)-[a-z0-9-]+$'
 limits:
   max_changed_files_non_content: 25
   max_changed_lines_non_content: 1200

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -42,40 +42,49 @@ end
 data = YAML.safe_load(File.read(active_plan), permitted_classes: [Date, Time], aliases: false) || {}
 plan_id = data["plan_id"].to_s.strip
 base_branch = data["base_branch"].to_s.strip
-branch_pattern = data["branch_pattern"].to_s.strip
+task_branch_pattern = data["task_branch_pattern"].to_s.strip
+phase_branch_pattern = data["phase_branch_pattern"].to_s.strip
 required_checks = data["required_checks"].is_a?(Array) ? data["required_checks"] : []
 
-if plan_id.empty? || base_branch.empty? || branch_pattern.empty?
-  warn "error: active rollout plan is missing plan_id/base_branch/branch_pattern"
+if plan_id.empty? || base_branch.empty? || task_branch_pattern.empty? || phase_branch_pattern.empty?
+  warn "error: active rollout plan is missing plan_id/base_branch/task_branch_pattern/phase_branch_pattern"
   exit 1
 end
 
-match = Regexp.new(branch_pattern).match(branch)
-if match.nil?
-  warn "error: branch #{branch.inspect} does not match active branch_pattern #{branch_pattern.inspect}"
+branch_mode = nil
+phase = nil
+
+phase_match = Regexp.new(phase_branch_pattern).match(branch)
+task_match = Regexp.new(task_branch_pattern).match(branch)
+if !phase_match.nil?
+  branch_mode = "phase"
+  phase = phase_match[1].to_i
+  if phase <= 0
+    warn "error: extracted phase must be >= 1 for branch #{branch.inspect}"
+    exit 1
+  end
+elsif !task_match.nil?
+  branch_mode = "task"
+else
+  warn "error: branch #{branch.inspect} does not match task pattern #{task_branch_pattern.inspect} or phase pattern #{phase_branch_pattern.inspect}"
   exit 1
 end
 
-phase = match[1].to_i
-if phase <= 0
-  warn "error: extracted phase must be >= 1 for branch #{branch.inspect}"
-  exit 1
-end
-
-puts "#{plan_id}\t#{base_branch}\t#{phase}\t#{branch_pattern}\t#{required_checks.join(',')}"
+puts "#{plan_id}\t#{base_branch}\t#{branch_mode}\t#{phase}\t#{phase_branch_pattern}\t#{required_checks.join(',')}"
 RUBY
 )"
 
 plan_id="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $1}')"
 base_branch="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $2}')"
-phase="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $3}')"
-branch_pattern="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $4}')"
-required_checks="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $5}')"
+branch_mode="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $3}')"
+phase="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $4}')"
+phase_branch_pattern="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $5}')"
+required_checks="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $6}')"
 
-if [[ "$phase" -gt 1 ]]; then
+if [[ "$branch_mode" == "phase" && "$phase" -gt 1 ]]; then
   pr_index="$(gh pr list --state all --base "$base_branch" --limit 200 --json number,state,mergedAt,headRefName)"
 
-  ruby - "$pr_index" "$branch_pattern" "$phase" <<'RUBY'
+  ruby - "$pr_index" "$phase_branch_pattern" "$phase" <<'RUBY'
 require "json"
 
 prs = JSON.parse(ARGV.fetch(0))
@@ -159,7 +168,8 @@ cat > "$body_file" <<EOF
 ## Rollout Metadata
 
 - plan_id: \`$plan_id\`
-- phase: \`$phase\`
+- branch_mode: \`$branch_mode\`
+- phase: \`${phase:-n/a}\`
 - required_checks: \`$required_checks\`
 
 ## Validation

--- a/scripts/finalize-merge.sh
+++ b/scripts/finalize-merge.sh
@@ -35,11 +35,12 @@ end
 data = YAML.safe_load(File.read(active_plan), permitted_classes: [Date, Time], aliases: false) || {}
 plan_id = data["plan_id"].to_s.strip
 base_branch = data["base_branch"].to_s.strip
-branch_pattern = data["branch_pattern"].to_s.strip
+task_branch_pattern = data["task_branch_pattern"].to_s.strip
+phase_branch_pattern = data["phase_branch_pattern"].to_s.strip
 required_checks = data["required_checks"].is_a?(Array) ? data["required_checks"] : []
 
-if plan_id.empty? || base_branch.empty? || branch_pattern.empty?
-  warn "error: active rollout plan is missing plan_id/base_branch/branch_pattern"
+if plan_id.empty? || base_branch.empty? || task_branch_pattern.empty? || phase_branch_pattern.empty?
+  warn "error: active rollout plan is missing plan_id/base_branch/task_branch_pattern/phase_branch_pattern"
   exit 1
 end
 
@@ -48,37 +49,44 @@ if required_checks.empty?
   exit 1
 end
 
-puts "#{plan_id}\t#{base_branch}\t#{branch_pattern}\t#{required_checks.join(',')}"
+puts "#{plan_id}\t#{base_branch}\t#{task_branch_pattern}\t#{phase_branch_pattern}\t#{required_checks.join(',')}"
 RUBY
 )"
 
 plan_id="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $1}')"
 base_branch="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $2}')"
-branch_pattern="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $3}')"
-required_checks_csv="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $4}')"
+task_branch_pattern="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $3}')"
+phase_branch_pattern="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $4}')"
+required_checks_csv="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $5}')"
 
 pr_state="$(gh pr view "$pr" --json number,statusCheckRollup,isDraft,url,baseRefName,headRefName,state)"
 
 validation="$(
-  ruby - "$pr_state" "$base_branch" "$branch_pattern" "$required_checks_csv" <<'RUBY'
+  ruby - "$pr_state" "$base_branch" "$task_branch_pattern" "$phase_branch_pattern" "$required_checks_csv" <<'RUBY'
 require "json"
 
 pr = JSON.parse(ARGV.fetch(0))
 base_branch = ARGV.fetch(1)
-branch_pattern = Regexp.new(ARGV.fetch(2))
-required_checks = ARGV.fetch(3).split(",").map(&:strip).reject(&:empty?)
+task_branch_pattern = Regexp.new(ARGV.fetch(2))
+phase_branch_pattern = Regexp.new(ARGV.fetch(3))
+required_checks = ARGV.fetch(4).split(",").map(&:strip).reject(&:empty?)
 
 errors = []
 errors << "PR is still a draft" if pr["isDraft"] == true
 errors << "PR base #{pr["baseRefName"].inspect} must be #{base_branch.inspect}" if pr["baseRefName"] != base_branch
 
 head = pr["headRefName"].to_s
-match = branch_pattern.match(head)
-if match.nil?
-  errors << "PR head branch #{head.inspect} does not match required phase pattern"
-else
-  phase = match[1].to_i
+branch_mode = nil
+phase = nil
+
+if (phase_match = phase_branch_pattern.match(head))
+  branch_mode = "phase"
+  phase = phase_match[1].to_i
   errors << "phase extracted from branch must be >= 1" if phase <= 0
+elsif task_branch_pattern.match(head)
+  branch_mode = "task"
+else
+  errors << "PR head branch #{head.inspect} does not match task or phase branch patterns"
 end
 
 checks = pr["statusCheckRollup"] || []
@@ -109,18 +117,18 @@ if errors.any?
   exit 1
 end
 
-phase = match[1].to_i
-puts [pr["url"], phase, head].join("\t")
+puts [pr["url"], branch_mode, phase, head].join("\t")
 RUBY
 )"
 
 pr_url="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $1}')"
-phase="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $2}')"
-head_branch="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $3}')"
+branch_mode="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $2}')"
+phase="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $3}')"
+head_branch="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $4}')"
 
-if [[ "$phase" -gt 1 ]]; then
+if [[ "$branch_mode" == "phase" && "$phase" -gt 1 ]]; then
   pr_index="$(gh pr list --state all --base "$base_branch" --limit 200 --json number,state,mergedAt,headRefName)"
-  ruby - "$pr_index" "$branch_pattern" "$phase" <<'RUBY'
+  ruby - "$pr_index" "$phase_branch_pattern" "$phase" <<'RUBY'
 require "json"
 
 prs = JSON.parse(ARGV.fetch(0))
@@ -181,7 +189,8 @@ fi
 cat <<EOF
 Self-review checklist for $pr_url
 - plan: $plan_id
-- phase: $phase
+- branch mode: $branch_mode
+- phase: ${phase:-n/a}
 - head branch: $head_branch
 - full local QA gate passed (\`make qa-local\`)
 - diff reviewed

--- a/scripts/start-phase.sh
+++ b/scripts/start-phase.sh
@@ -38,20 +38,20 @@ path = ARGV.fetch(0)
 data = YAML.safe_load(File.read(path), permitted_classes: [Date, Time], aliases: false) || {}
 plan_id = data["plan_id"].to_s.strip
 base_branch = data["base_branch"].to_s.strip
-branch_pattern = data["branch_pattern"].to_s.strip
+phase_branch_pattern = data["phase_branch_pattern"].to_s.strip
 
-if plan_id.empty? || base_branch.empty? || branch_pattern.empty?
-  warn "error: active rollout plan missing required keys (plan_id/base_branch/branch_pattern)"
+if plan_id.empty? || base_branch.empty? || phase_branch_pattern.empty?
+  warn "error: active rollout plan missing required keys (plan_id/base_branch/phase_branch_pattern)"
   exit 1
 end
 
-puts "#{plan_id}\t#{base_branch}\t#{branch_pattern}"
+puts "#{plan_id}\t#{base_branch}\t#{phase_branch_pattern}"
 RUBY
 )"
 
 active_plan_id="$(printf '%s' "$active_info" | awk -F '\t' 'NR==1 {print $1}')"
 base_branch="$(printf '%s' "$active_info" | awk -F '\t' 'NR==1 {print $2}')"
-branch_pattern="$(printf '%s' "$active_info" | awk -F '\t' 'NR==1 {print $3}')"
+phase_branch_pattern="$(printf '%s' "$active_info" | awk -F '\t' 'NR==1 {print $3}')"
 
 if [[ -z "$plan" ]]; then
   plan="$active_plan_id"
@@ -97,13 +97,13 @@ inferred="$("$repo_root/.agents/skills/repo-flow/scripts/infer-branch-name.sh" "
 suffix="${inferred#codex/"${type}"-}"
 branch_name="codex/phase-${phase}-${suffix}"
 
-ruby - "$branch_name" "$branch_pattern" <<'RUBY'
+ruby - "$branch_name" "$phase_branch_pattern" <<'RUBY'
 branch_name = ARGV.fetch(0)
-branch_pattern = ARGV.fetch(1)
+phase_branch_pattern = ARGV.fetch(1)
 
-match = Regexp.new(branch_pattern).match(branch_name)
+match = Regexp.new(phase_branch_pattern).match(branch_name)
 if match.nil?
-  warn "error: generated branch #{branch_name.inspect} does not match branch_pattern #{branch_pattern.inspect}"
+  warn "error: generated branch #{branch_name.inspect} does not match phase_branch_pattern #{phase_branch_pattern.inspect}"
   exit 1
 end
 RUBY

--- a/scripts/tests/rollout_governance_test.rb
+++ b/scripts/tests/rollout_governance_test.rb
@@ -33,7 +33,8 @@ class RolloutGovernanceTest < Minitest::Test
       "apply_to_all_prs" => true,
       "mode" => "sequential",
       "base_branch" => "main",
-      "branch_pattern" => "^codex/phase-(\\d+)-[a-z0-9-]+$",
+      "task_branch_pattern" => "^codex/cws-\\d+-[a-z0-9-]+$",
+      "phase_branch_pattern" => "^codex/phase-(\\d+)-[a-z0-9-]+$",
       "limits" => {
         "max_changed_files_non_content" => 25,
         "max_changed_lines_non_content" => 1200,
@@ -75,6 +76,26 @@ class RolloutGovernanceTest < Minitest::Test
       write_evidence(7)
       stdout, stderr, status = run_validator(env: { "GITHUB_HEAD_REF" => "codex/phase-1-unrelated" })
       assert status.success?, "expected success, got stderr: #{stderr}\nstdout: #{stdout}"
+    end
+  end
+  def test_accepts_valid_cws_branch_without_phase_enforcement
+    with_repo(branch: "codex/cws-16-branch-policy") do
+      write_active_plan
+      write_contiguous_phases(1)
+      write_evidence(1)
+      stdout, stderr, status = run_validator
+      assert status.success?, "expected success, got stderr: #{stderr}\nstdout: #{stdout}"
+      assert_match(/branch_mode=task/, stdout)
+    end
+  end
+  def test_rejects_invalid_non_matching_branch
+    with_repo(branch: "feature/cws-16-branch-policy") do
+      write_active_plan
+      write_contiguous_phases(1)
+      write_evidence(1)
+      _stdout, stderr, status = run_validator
+      refute status.success?
+      assert_match(/does not match task pattern/i, stderr)
     end
   end
   def test_dynamic_phase_count_accepts_single_phase_plan

--- a/scripts/validate-rollout-governance.rb
+++ b/scripts/validate-rollout-governance.rb
@@ -109,7 +109,8 @@ plan_id = plan["plan_id"].to_s.strip
 apply_to_all_prs = plan["apply_to_all_prs"] == true
 mode = plan["mode"].to_s.strip
 base_branch = plan["base_branch"].to_s.strip
-branch_pattern = plan["branch_pattern"].to_s.strip
+task_branch_pattern = plan["task_branch_pattern"].to_s.strip
+phase_branch_pattern = plan["phase_branch_pattern"].to_s.strip
 limits = plan["limits"].is_a?(Hash) ? plan["limits"] : {}
 max_changed_files_non_content = limits["max_changed_files_non_content"]
 max_changed_lines_non_content = limits["max_changed_lines_non_content"]
@@ -119,7 +120,8 @@ errors << "active-plan.yaml missing plan_id" if plan_id.empty?
 errors << "active-plan.yaml must set apply_to_all_prs=true" unless apply_to_all_prs
 errors << "active-plan.yaml mode must be sequential" unless mode == "sequential"
 errors << "active-plan.yaml missing base_branch" if base_branch.empty?
-errors << "active-plan.yaml missing branch_pattern" if branch_pattern.empty?
+errors << "active-plan.yaml missing task_branch_pattern" if task_branch_pattern.empty?
+errors << "active-plan.yaml missing phase_branch_pattern" if phase_branch_pattern.empty?
 errors << "active-plan.yaml limits.max_changed_files_non_content must be a positive integer" unless max_changed_files_non_content.is_a?(Integer) && max_changed_files_non_content.positive?
 errors << "active-plan.yaml limits.max_changed_lines_non_content must be a positive integer" unless max_changed_lines_non_content.is_a?(Integer) && max_changed_lines_non_content.positive?
 errors << "active-plan.yaml limits.ignore_paths_for_size_caps must be a non-empty list" if ignore_paths_for_size_caps.empty?
@@ -134,18 +136,25 @@ if branch.to_s.strip.empty?
 end
 
 phase = nil
+branch_mode = nil
 if branch == base_branch
   puts "rollout governance check skipped for base branch #{base_branch}"
   exit 0 if errors.empty?
 elsif branch.empty?
   errors << "unable to detect current branch"
 else
-  match = Regexp.new(branch_pattern).match(branch) rescue nil
-  if match.nil?
-    errors << "branch #{branch.inspect} does not match required phase pattern #{branch_pattern.inspect}" if apply_to_all_prs
-  else
-    phase = match[1].to_i
+  phase_match = Regexp.new(phase_branch_pattern).match(branch) rescue nil
+  task_match = Regexp.new(task_branch_pattern).match(branch) rescue nil
+  if !phase_match.nil?
+    branch_mode = "phase"
+    phase = phase_match[1].to_i
     errors << "phase extracted from branch must be >= 1" if phase <= 0
+  elsif !task_match.nil?
+    branch_mode = "task"
+  else
+    if apply_to_all_prs
+      errors << "branch #{branch.inspect} does not match task pattern #{task_branch_pattern.inspect} or phase pattern #{phase_branch_pattern.inspect}"
+    end
   end
 end
 
@@ -176,6 +185,11 @@ end
 if errors.any?
   errors.each { |error| warn "error: #{error}" }
   exit 1
+end
+
+if branch_mode == "task"
+  puts "rollout governance check passed for plan=#{plan_id} branch_mode=task"
+  exit 0
 end
 
 manifest_path = File.join(plan_dir, "phase-#{phase}.txt")


### PR DESCRIPTION
## Summary

- cws 16 branch policy dual mode

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Rollout Metadata

- plan_id: `governance-v3`
- branch_mode: `task`
- phase: `n/a`
- required_checks: `build,semgrep,rollout-governance`

## Validation

- `make qa-local`

## Affected Files

```text
.codex/config.toml
.codex/docs/multi-agent-red-team.md
.codex/docs/multi-agent-rollout-checklist.md
.codex/docs/workflows.md
.codex/rollout/active-plan.yaml
scripts/create-pr.sh
scripts/finalize-merge.sh
scripts/start-phase.sh
scripts/tests/rollout_governance_test.rb
scripts/validate-rollout-governance.rb
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
