### PR TITLE
docs: cws 50 gate policy backfill

### DIFF
--- a/.codex/docs/templates/dev-intake-template.md
+++ b/.codex/docs/templates/dev-intake-template.md
@@ -1,0 +1,43 @@
+# DEV Intake Template
+
+## Objective
+
+## Scope In
+
+## Scope Out
+
+## Validation Commands
+
+## Gate Type
+
+Choose exactly one:
+
+- `PR_REQUIRED` for tasks that modify tracked repository files.
+- `EVIDENCE_REQUIRED` for tasks that do not require a repository PR.
+
+## Completion Gate
+
+### If `PR_REQUIRED`
+
+- [ ] PR created and linked to this issue
+- [ ] PR moved to `In Review`
+- [ ] Review completed (or explicit self-review recorded for solo flow)
+- [ ] PR merged to `main`
+- [ ] Only after merge: move issue to `Done`
+
+### If `EVIDENCE_REQUIRED`
+
+- [ ] Required evidence artifact(s) attached (screenshots, links, logs, or decision notes)
+- [ ] Human verification/sign-off comment posted
+- [ ] Scope acceptance criteria confirmed in comment
+- [ ] Only after evidence is complete: move issue to `Done`
+
+## Pickup Gate
+
+## Missing For Pickup
+
+## DoR
+
+## DoD
+
+- [ ] Completion gate satisfied for selected `Gate Type`

--- a/.codex/docs/templates/editorial-new-intake-template.md
+++ b/.codex/docs/templates/editorial-new-intake-template.md
@@ -1,0 +1,43 @@
+# Editorial New Intake Template
+
+## Objective
+
+## Scope In
+
+## Scope Out
+
+## Validation Commands
+
+## Gate Type
+
+Choose exactly one:
+
+- `PR_REQUIRED` for tasks that modify tracked repository files.
+- `EVIDENCE_REQUIRED` for tasks that do not require a repository PR.
+
+## Completion Gate
+
+### If `PR_REQUIRED`
+
+- [ ] PR created and linked to this issue
+- [ ] PR moved to `In Review`
+- [ ] Review completed (or explicit self-review recorded for solo flow)
+- [ ] PR merged to `main`
+- [ ] Only after merge: move issue to `Done`
+
+### If `EVIDENCE_REQUIRED`
+
+- [ ] Required evidence artifact(s) attached (screenshots, links, logs, or decision notes)
+- [ ] Human verification/sign-off comment posted
+- [ ] Scope acceptance criteria confirmed in comment
+- [ ] Only after evidence is complete: move issue to `Done`
+
+## Pickup Gate
+
+## Missing For Pickup
+
+## DoR
+
+## DoD
+
+- [ ] Completion gate satisfied for selected `Gate Type`

--- a/.codex/docs/templates/editorial-update-intake-template.md
+++ b/.codex/docs/templates/editorial-update-intake-template.md
@@ -1,0 +1,43 @@
+# Editorial Update Intake Template
+
+## Objective
+
+## Scope In
+
+## Scope Out
+
+## Validation Commands
+
+## Gate Type
+
+Choose exactly one:
+
+- `PR_REQUIRED` for tasks that modify tracked repository files.
+- `EVIDENCE_REQUIRED` for tasks that do not require a repository PR.
+
+## Completion Gate
+
+### If `PR_REQUIRED`
+
+- [ ] PR created and linked to this issue
+- [ ] PR moved to `In Review`
+- [ ] Review completed (or explicit self-review recorded for solo flow)
+- [ ] PR merged to `main`
+- [ ] Only after merge: move issue to `Done`
+
+### If `EVIDENCE_REQUIRED`
+
+- [ ] Required evidence artifact(s) attached (screenshots, links, logs, or decision notes)
+- [ ] Human verification/sign-off comment posted
+- [ ] Scope acceptance criteria confirmed in comment
+- [ ] Only after evidence is complete: move issue to `Done`
+
+## Pickup Gate
+
+## Missing For Pickup
+
+## DoR
+
+## DoD
+
+- [ ] Completion gate satisfied for selected `Gate Type`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,13 @@
 - Ensure local checks pass before opening a PR. CI is backup only, not the primary development loop.
 - Branching model is trunk-based development: create short-lived branches off `main`, rebase if they drift, and integrate back with rebase only.
 
+### Graphite And GitHub CLI Policy
+
+- Use Graphite CLI (`gt`) for stack lifecycle operations: `gt create`, `gt modify`, `gt restack`, `gt sync`, and `gt submit --no-interactive`.
+- Use GitHub CLI (`gh`) for GitHub object operations after submission: inspecting checks, viewing diffs, reading review state, commenting, and labeling.
+- Keep branch/stack state authoritative in `gt`; use `gh` as the GitHub surface inspection and operations layer.
+- For stacked PR work, avoid mixing direct `git push`/`git commit` with Graphite stack steps unless explicitly required for recovery.
+
 ## Review Guidelines
 
 - For Codex GitHub reviews, prioritize high-impact findings first: regressions, correctness bugs, security risks, and workflow breakage.

--- a/docs/linear-gate-backfill-report-2026-03-16.md
+++ b/docs/linear-gate-backfill-report-2026-03-16.md
@@ -1,0 +1,67 @@
+# Linear Gate Backfill Report (2026-03-16)
+
+- Scope: all non-archived issues CWS-5 through CWS-60
+- Verification mode: exhaustive (100% ID coverage)
+- Notes:
+  - Gate classification/checklist posted on each issue as a canonical comment.
+  - `EVIDENCE_REQUIRED` applied to non-repo tasks (`CWS-7`, `CWS-28`).
+  - All others set to `PR_REQUIRED`.
+
+| Issue | Gate Type | Verification | Remediation Action |
+| --- | --- | --- | --- |
+| CWS-5 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-6 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-7 | EVIDENCE_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-8 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-9 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-10 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-11 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-12 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-13 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-14 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-15 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-16 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-17 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-18 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-19 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-20 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-21 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-22 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-23 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-24 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-25 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-26 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-27 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-28 | EVIDENCE_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-29 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-30 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-31 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-32 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-33 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-34 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-35 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-36 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-37 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-38 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-39 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-40 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-41 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-42 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-43 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-44 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-45 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-46 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-47 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-48 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-49 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-50 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-51 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-52 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-53 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-54 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-55 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-56 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-57 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-58 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-59 | PR_REQUIRED | PASS | Canonical gate comment posted |
+| CWS-60 | PR_REQUIRED | PASS | Canonical gate comment posted |

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -1750,6 +1750,9 @@ This plan is complete when all of the following are true:
 - `_drafts/` is tracked by git and agents can create/edit drafts in branches.
 - Every meaningful change starts as a Linear issue.
 - Every issue clearly indicates executor and bottleneck state.
+- Every issue declares exactly one completion gate type: `PR_REQUIRED` or `EVIDENCE_REQUIRED`.
+- `PR_REQUIRED` issues cannot move to `Done` until the linked PR is merged to `main`.
+- `EVIDENCE_REQUIRED` issues cannot move to `Done` without explicit evidence artifacts and human sign-off.
 - Branches use `CWS-*` identifiers.
 - Per-task files exist at `docs/tasks/CWS-NNN.md` and persist after merge.
 - Hooks catch most failures before push.


### PR DESCRIPTION
## Summary

- cws 50 gate policy backfill

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Rollout Metadata

- plan_id: `governance-v3`
- branch_mode: `task`
- phase: `n/a`
- required_checks: `build,semgrep,rollout-governance`

## Validation

- `make qa-local`

## Affected Files

```text
.codex/docs/templates/dev-intake-template.md
.codex/docs/templates/editorial-new-intake-template.md
.codex/docs/templates/editorial-update-intake-template.md
AGENTS.md
docs/linear-gate-backfill-report-2026-03-16.md
docs/master-plan.md
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
