### PR TITLE
style(cws-64): clean up markdownlint debt in docs/master-plan.md

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -42,3 +42,6 @@ config_file = "agents/publisher-release.toml"
 [agents.historical-post-editor]
 description = "Preservation-safe implementer for existing tracked posts with protected historical text and dates."
 config_file = "agents/historical-post-editor.toml"
+
+[sandbox_workspace_write]
+network_access = true

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable MD024 MD029 MD031 MD032 MD036 MD037 MD040 MD060 -->
-
 # CodeWithShabib Agentic Workflow Master Plan
 
 _Last updated: 2026-03-15_
@@ -11,10 +9,12 @@ _Version: 3.3 — validated against March 2026 official documentation_
 ## Document Location and Versioning
 
 This Master Plan is stored in two locations:
+
 1. **Primary (versioned):** `docs/master-plan.md` in the `shabib87/shabib87.github.io` repository. Changes to this file are tracked by git and follow the same PR workflow as all repo changes. Major revisions should reference an ADR.
 2. **Reference copy in Linear:** Attach the current version as a Linear document or paste into the project description of `[ORCHESTRATION] Agentic Workflow Design`. This is a read reference only — the repo copy is authoritative.
 
 The plan is NOT stored only in Linear because:
+
 - Linear documents are not git-versioned
 - Linear does not support diff/PR review of document changes
 - The plan references repo structure that should be co-located
@@ -26,6 +26,7 @@ The plan is NOT stored only in Linear because:
 This document is the single source of truth for the agentic operating model for the `shabib87/shabib87.github.io` repository. It consolidates the current-state audit, constraints, target architecture, Linear operating model, Codex orchestration design, editorial quality system, CI strategy, ADR strategy, Slack setup, and the implementation backlog discussed across the planning sessions.
 
 The goal is to run this repository like a small specialist team:
+
 - **Shabib** is the human principal, reviewer, editor-in-chief, and final approver.
 - **Codex agents** are specialist contributors that execute scoped work.
 - **Linear** is the source of truth for planning, status, ownership, and bottlenecks.
@@ -81,7 +82,7 @@ Everything between those two steps is automated: dispatch, branch prep, task fil
 
 A ticket must meet ALL of the following criteria before an agent can pick it up.
 
-**Definition of Ready for agent-pickable tickets:**
+Definition of Ready for agent-pickable tickets:
 
 1. **Linear issue exists** with status = `Todo` and label = `agent-task`
 2. **Title follows convention:** `[DEV]`, `[EDITORIAL-NEW]`, or `[EDITORIAL-UPDATE]` prefix
@@ -92,7 +93,8 @@ A ticket must meet ALL of the following criteria before an agent can pick it up.
 7. **Dependencies are resolved:** No blockers from other issues. If the issue depends on another, that issue must be `Done`.
 8. **Required skills exist:** If the task needs a specific Codex skill, that skill must already be committed to the repo.
 
-**Who enforces DoR:**
+Who enforces DoR:
+
 - The dispatch workflow enforces items 1-3 and 6 (automated).
 - Shabib enforces items 4-5, 7-8 (human judgment at issue creation time).
 - Codex agents should CHECK DoR at the start of every task and refuse to proceed if any item fails, posting a comment on the Linear issue explaining what's missing.
@@ -116,6 +118,7 @@ The repository already has meaningful automation and orchestration foundations:
 ### Existing content posture
 
 The blog has a mix of older iOS-era posts and stronger recent principal-level posts. This means the repo needs two editorial tracks:
+
 - **new post creation** (drafts start in `_drafts/`, move to `_posts/` on publish)
 - **historical post UX/SEO refresh without rewriting original prose**
 
@@ -143,18 +146,19 @@ These constraints are mandatory and drive every design choice.
 
 ### Shabib's device profile
 
-| Device | OS | Role in workflow |
-|---|---|---|
-| Mac (desktop/laptop) | macOS | Primary development, Codex (CLI, App, IDE extension), GitHub, Linear, Graphite CLI, local Jekyll builds |
-| iPhone | iOS | Perplexity, ChatGPT (+ Codex Cloud sidebar), Linear, Slack, GitHub — idea capture and task triage on the go |
-| Android phone | Android | Perplexity, ChatGPT, Linear, Slack — secondary mobile surface, same capabilities as iOS |
-| GitHub-hosted runners | Linux | CI only — runs GitHub Actions workflows. Not a user-facing surface. |
+| Device                | OS      | Role in workflow                                                                                            |
+| --------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| Mac (desktop/laptop)  | macOS   | Primary development, Codex (CLI, App, IDE extension), GitHub, Linear, Graphite CLI, local Jekyll builds     |
+| iPhone                | iOS     | Perplexity, ChatGPT (+ Codex Cloud sidebar), Linear, Slack, GitHub — idea capture and task triage on the go |
+| Android phone         | Android | Perplexity, ChatGPT, Linear, Slack — secondary mobile surface, same capabilities as iOS                     |
+| GitHub-hosted runners | Linux   | CI only — runs GitHub Actions workflows. Not a user-facing surface.                                         |
 
 **No Windows machines.** All tooling, scripts, Makefiles, and documentation must assume macOS for local development and Linux for CI. No PowerShell, no `.bat`/`.cmd` files, no Windows path separators.
 
 ### Scripting language policy
 
 The repo currently has:
+
 - **22 bash scripts** (.sh) — all orchestration, setup, lint, QA, CI, hooks, repo-flow
 - **2 Ruby validation scripts** — `validate-multi-agent-contracts.rb`, `validate-rollout-governance.rb`
 - **2 Ruby library files** — `publish_draft.rb`, `publish_draft_core.rb` (the publish-draft pipeline)
@@ -162,7 +166,8 @@ The repo currently has:
 - **1 bash library** — `tooling.sh`
 - The **Makefile** (bash shell) dispatches everything
 
-**Policy:**
+Policy:
+
 - **Keep both languages.** Bash is the orchestration glue (90% of scripts). Ruby is used where Jekyll ecosystem alignment matters — publishing drafts, YAML/front-matter parsing, and validation logic that benefits from Minitest + structured error handling.
 - **Rule:** New scripts default to bash. Use Ruby only when: (a) the script deeply interacts with Jekyll/YAML structures, (b) the logic requires test coverage via Minitest, or (c) it's extending existing Ruby modules.
 - **Makefile remains the single entry point.** All scripts are invoked through `make` targets — neither agents nor humans should call scripts directly.
@@ -195,12 +200,14 @@ The `_drafts/` folder is currently in `.gitignore`. Agents cannot create or coll
 ### 2. CI is not yet intentionally split
 
 Current workflows are useful but not optimized for cost or clarity. The system needs separate pipelines for:
+
 - **development / tooling / infrastructure work**
 - **editorial / post-quality work**
 
 ### 3. Local validation is not yet the primary gate
 
 The correct cost-aware pattern is:
+
 - fast checks in **pre-commit**
 - heavier validation in **pre-push**
 - CI as confirmation, not discovery
@@ -212,6 +219,7 @@ Scripts exist, but not every script has complete test coverage. Tests need to be
 ### 5. Editorial quality is only partially codified
 
 The desired editorial quality system includes:
+
 - front matter validation
 - markdown lint
 - spelling
@@ -249,12 +257,14 @@ The current `CODEX_TASK.md` is a single file at a fixed location. It should be p
 
 **Available surfaces:** iOS app, Android app, Mac app (Perplexity Computer), web app (perplexity.ai).
 
-**Connected integrations (already active):**
+Connected integrations (already active):
+
 - **Linear** — create issues, query workspace
 - **GitHub** — read repos, trigger workflow_dispatch via GitHub connector
 - **Slack** — post messages, read channels
 
-**Use for:**
+Use for:
+
 - Idea shaping and research
 - Repo-aware discussion
 - Linear issue creation (via Linear connector)
@@ -265,18 +275,21 @@ The current `CODEX_TASK.md` is a single file at a fixed location. It should be p
 
 **Available surfaces:** iOS app, Android app, Mac desktop app, web app (chatgpt.com).
 
-**Capabilities:**
+Capabilities:
+
 - **GitHub app connection** (Settings → Apps → GitHub): read-only access to repos for code analysis and discussion. **Cannot push code or trigger workflows directly.** Code changes go through Codex.
 - **Codex Cloud** (sidebar in ChatGPT web, or via chatgpt.com/codex): delegate coding tasks that run in sandboxed cloud environments, produce PRs on connected GitHub repos. Also accessible from ChatGPT iOS/Android.
 - **Codex App** (standalone Mac desktop app): multi-agent management, worktrees, automations.
 
-**Use for:**
+Use for:
+
 - Idea shaping and discussion
 - Linear issue creation (via conversation, then manual creation or Codex task)
 - Delegating Codex Cloud tasks from any surface (iOS, Android, Mac, web) via the Codex sidebar
 - Code Q&A with connected GitHub repos
 
 **Important limitation:** ChatGPT's GitHub integration is **read-only**. To trigger `workflow_dispatch`, use one of:
+
 1. Perplexity (via GitHub connector)
 2. `gh workflow run` from CLI
 3. GitHub REST API call
@@ -284,16 +297,17 @@ The current `CODEX_TASK.md` is a single file at a fixed location. It should be p
 
 ### Codex (CLI, Mac App, IDE Extension, Cloud)
 
-**Available surfaces as of March 2026:**
+Available surfaces as of March 2026:
 
-| Surface | Platform | Status |
-|---|---|---|
-| Codex CLI | macOS (user), Linux (CI-only) | Stable, open-source, Rust-based |
-| Codex Mac App | macOS (Apple Silicon) | Stable since Feb 2026 |
-| Codex IDE Extension | VS Code, Cursor, Windsurf, JetBrains (macOS) | Stable |
-| Codex Cloud | Web (chatgpt.com/codex), ChatGPT iOS/Android sidebar | Stable |
+| Surface             | Platform                                             | Status                          |
+| ------------------- | ---------------------------------------------------- | ------------------------------- |
+| Codex CLI           | macOS (user), Linux (CI-only)                        | Stable, open-source, Rust-based |
+| Codex Mac App       | macOS (Apple Silicon)                                | Stable since Feb 2026           |
+| Codex IDE Extension | VS Code, Cursor, Windsurf, JetBrains (macOS)         | Stable                          |
+| Codex Cloud         | Web (chatgpt.com/codex), ChatGPT iOS/Android sidebar | Stable                          |
 
-**Key capabilities:**
+Key capabilities:
+
 - Multi-agent support (experimental in CLI; native in app)
 - Worktrees for isolated agent work (app)
 - Skills system (`.agents/skills/`) for repeatable workflows
@@ -359,7 +373,7 @@ A single `CODEX_TASK.md` creates conflicts when multiple tasks are in flight and
 
 ### Location and naming
 
-```
+```text
 docs/tasks/CWS-NNN.md
 ```
 
@@ -367,11 +381,11 @@ Where `NNN` is the Linear issue number (e.g., `docs/tasks/CWS-42.md`).
 
 ### Lifecycle
 
-| Phase | State |
-|---|---|
-| Dispatch workflow runs | File created at `docs/tasks/CWS-NNN.md` with Linear issue content |
-| Codex picks up task | Agent reads from `docs/tasks/CWS-NNN.md` |
-| Task complete, PR merged | File persists as historical record |
+| Phase                    | State                                                             |
+| ------------------------ | ----------------------------------------------------------------- |
+| Dispatch workflow runs   | File created at `docs/tasks/CWS-NNN.md` with Linear issue content |
+| Codex picks up task      | Agent reads from `docs/tasks/CWS-NNN.md`                          |
+| Task complete, PR merged | File persists as historical record                                |
 
 ### File structure
 
@@ -379,6 +393,7 @@ Where `NNN` is the Linear issue number (e.g., `docs/tasks/CWS-42.md`).
 # CWS-NNN: [Issue Title]
 
 ## Linear Issue
+
 - **ID:** CWS-NNN
 - **URL:** https://linear.app/codewithshabib/issue/CWS-NNN
 - **Workflow:** [Dev | Editorial-New | Editorial-Update]
@@ -386,15 +401,19 @@ Where `NNN` is the Linear issue number (e.g., `docs/tasks/CWS-42.md`).
 - **Created:** YYYY-MM-DD
 
 ## Brief
+
 [Full issue description from Linear]
 
 ## Acceptance Criteria
+
 [Extracted from issue body]
 
 ## Labels
+
 [Labels from Linear]
 
 ## Decomposition
+
 [Sub-issues if any, with their CWS IDs]
 ```
 
@@ -420,6 +439,7 @@ Every orchestrator prompt must reference the task file by its per-task path:
 ### Clean-up step
 
 Archive the default Linear onboarding issues before creating the real backlog:
+
 - `CWS-1`
 - `CWS-2`
 - `CWS-3`
@@ -430,6 +450,7 @@ These are onboarding artifacts, not project work.
 ### Statuses
 
 Use the existing team workflow states:
+
 - Backlog
 - Todo
 - In Progress
@@ -443,6 +464,7 @@ Use the existing team workflow states:
 #### Executor
 
 Exactly one of:
+
 - `Human`
 - `Agent`
 - `Hybrid`
@@ -450,6 +472,7 @@ Exactly one of:
 #### Bottleneck
 
 Exactly one of:
+
 - `Waiting-Human`
 - `Waiting-Agent`
 - `Ready`
@@ -457,6 +480,7 @@ Exactly one of:
 #### Workflow
 
 Exactly one of:
+
 - `Dev`
 - `Editorial-New`
 - `Editorial-Update`
@@ -464,6 +488,7 @@ Exactly one of:
 #### Stage
 
 Exactly one of:
+
 - `Spec`
 - `Implementation`
 - `Review`
@@ -472,6 +497,7 @@ Exactly one of:
 #### Type / focus tags
 
 Reusable labels:
+
 - `Epic`
 - `Task`
 - `Chore`
@@ -489,6 +515,7 @@ Reusable labels:
 #### Human means
 
 A task requires Shabib to:
+
 - make a decision
 - define policy
 - review architecture
@@ -506,6 +533,7 @@ An agent can do most of the implementation, but the task includes a human checkp
 ### Linear ↔ GitHub integration
 
 Linear's native GitHub integration (free, included) provides:
+
 - PR linking via branch name containing issue ID (e.g., `feature/CWS-42-short-slug`)
 - Automatic status transitions: issue moves to In Progress when PR is opened, Done when merged
 - Bidirectional comment sync
@@ -529,6 +557,7 @@ The `CWS-NNN` in the branch name triggers Linear's GitHub integration to auto-li
 ### PR body requirement
 
 Every PR must include:
+
 - `Closes CWS-NNN`
 - summary
 - why
@@ -547,6 +576,7 @@ Every PR must include:
 #### Concern layers
 
 Examples of layers:
+
 - repo tooling / scripts
 - CI / automation
 - docs / ADR / prompts
@@ -555,13 +585,15 @@ Examples of layers:
 
 #### Examples
 
-**Single PR examples:**
+Single PR examples:
+
 - add a front matter validator
 - update one hook
 - fix one editorial metadata issue
 - add one vale rule
 
-**Stack examples:**
+Stack examples:
+
 - introduce a new workflow that requires scripts + CI + docs
 - new editorial flow requiring prompts + validators + docs + templates
 - repo reorganization requiring scripts + Makefile + docs + CI changes
@@ -569,13 +601,15 @@ Examples of layers:
 #### Graphite free tier scope
 
 On the Hobby (free) tier, Graphite provides:
+
 - CLI for creating and managing stacked PRs (`gt create`, `gt submit`, `gt stack`)
 - VS Code extension
 - MCP integration
 - PR inbox and notifications
 - Limited AI reviews and chat
 
-**Not available on free tier:**
+Not available on free tier:
+
 - Slack notifications (requires Starter, $20/user/month)
 - Merge queue (requires Team, $40/user/month)
 - Automations (requires Team)
@@ -662,7 +696,7 @@ Purpose: catch fast editorial issues before a commit exists.
 - markdownlint
 - cspell
 
-#### Behaviour
+#### pre-commit behavior
 
 - if no editorial files are staged: exit 0
 - fast-fail with clear file-level error messages
@@ -678,7 +712,7 @@ Purpose: catch expensive failures before remote CI.
 - vale
 - SEO audit on changed posts
 
-#### Behaviour
+#### pre-push behavior
 
 - block push on any failure
 - show grouped error summary
@@ -703,6 +737,7 @@ Purpose: catch expensive failures before remote CI.
 ### dev-pipeline.yml
 
 Trigger paths:
+
 - `scripts/**`
 - `.codex/**`
 - `.agents/**`
@@ -713,7 +748,7 @@ Trigger paths:
 - `assets/**`
 - `.github/workflows/**`
 
-#### Job order
+#### dev-pipeline job order
 
 1. `test`
 2. `lint`
@@ -721,7 +756,7 @@ Trigger paths:
 4. `governance`
 5. `jekyll-build`
 
-#### Notes
+#### dev-pipeline notes
 
 - no deploy
 - ADR warning/check when architecture-level files change
@@ -729,10 +764,11 @@ Trigger paths:
 ### editorial-pipeline.yml
 
 Trigger paths:
+
 - `_posts/**`
 - `_drafts/**`
 
-#### Job order
+#### editorial-pipeline job order
 
 1. `test`
 2. `spell-check`
@@ -740,7 +776,7 @@ Trigger paths:
 4. `markdown-lint`
 5. `seo-audit`
 
-#### Notes
+#### editorial-pipeline notes
 
 - no Jekyll build required in baseline plan
 - no deploy
@@ -748,16 +784,18 @@ Trigger paths:
 
 ### Code security
 
-**Security scanning strategy:**
+Security scanning strategy:
 
-**Layer 1: Semgrep CE (local + CI)**
+Layer 1: Semgrep CE (local + CI)
+
 - Run Semgrep Community Edition with `--config auto` for Ruby, JavaScript, HTML, YAML
 - **Local:** Run in pre-push hook via `make security` (already exists as `run-security-checks.sh`, now covers Semgrep CE)
 - **CI:** Add `semgrep.yml` workflow triggered on PRs. Uses the free `semgrep/semgrep` Docker image. No `SEMGREP_APP_TOKEN` needed for CE mode — just `semgrep scan --config auto`.
 - **Cost:** Free. CE is fully open source. No account required for basic scanning.
 - **Why Semgrep:** Fast (no build required), works on source code directly, good for Ruby/JS/HTML. Catches injection, XSS, insecure patterns.
 
-**Layer 2: CodeQL (CI only)**
+Layer 2: CodeQL (CI only)
+
 - GitHub's native SAST. Free for public repositories (shabib87.github.io is public).
 - Add `codeql.yml` workflow triggered on PRs and push to `main`.
 - Use `github/codeql-action/init@v3` + `github/codeql-action/analyze@v3`
@@ -766,12 +804,14 @@ Trigger paths:
 - **Cost:** Free for public repos. Would require GitHub Advanced Security license ($49/seat/month) for private repos.
 - **Why CodeQL:** Deeper interprocedural analysis, good complement to Semgrep. Native GitHub integration means findings show inline on PRs.
 
-**Layer 3: Dependabot (already available)**
+Layer 3: Dependabot (already available)
+
 - GitHub Dependabot is already free and enabled by default on public repos.
 - Security updates for gems and npm packages.
 - No additional configuration needed beyond ensuring `Gemfile.lock` and `package-lock.json` are committed.
 
-**Security = first-class guardrail rule:**
+Security = first-class guardrail rule:
+
 - Security checks are blocking on PRs — same as tests (TDD) and lint.
 - No PR merges with critical/high Semgrep or CodeQL findings.
 - Security checks run in CI (not just local) because they are non-negotiable.
@@ -841,9 +881,11 @@ New posts follow the Jekyll `_drafts/` convention:
 ### Voice profile
 
 A new file is required:
+
 - `.codex/docs/editorial-voice-profile.md`
 
 It should define:
+
 - target audience
 - tone
 - sentence rhythm
@@ -855,9 +897,11 @@ It should define:
 ### Authority rubric
 
 A new file is required:
+
 - `.codex/docs/editorial-voice-eval-rubric.md`
 
 It should score:
+
 1. **Non-obvious perspective** — does this say more than a search result summary?
 2. **Concrete opinion** — does the piece take a position?
 3. **Experience signal** — does it reflect real trade-offs, not abstract restatement?
@@ -866,9 +910,11 @@ It should score:
 ### Vale custom rules
 
 Create a style pack in:
+
 - `styles/Codewithshabib/`
 
 Rules to include:
+
 - `NoPassiveVoice` / `ActiveVoicePreference`
 - `NoFillerOpeners`
 - `NoPrincipalHedging`
@@ -881,6 +927,7 @@ Rules to include:
 ### Roles already present in the repo
 
 The repo already has agent definitions for:
+
 - team-lead
 - researcher
 - developer
@@ -895,17 +942,17 @@ The repo already has agent definitions for:
 
 Each agent has a One Piece character identity that maps to their role. These identities are used in Codex `config.toml` agent definitions, skill descriptions, prompt headers, and Slack notifications for personality and quick identification.
 
-| Agent Name | One Piece Character | Role | Rationale |
-|---|---|---|---|
-| Luffy the Captain | Monkey D. Luffy | team-lead / orchestrator | Captain who sets direction and delegates to the crew |
-| Zoro the Swordsman | Roronoa Zoro | developer | First mate — cuts through problems with raw skill and discipline |
-| Nami the Navigator | Nami | researcher | Charts the course — finds information, maps the territory |
-| Sanji the Cook | Sanji | writer | Crafts something nourishing from raw ingredients — turns research into prose |
-| Chopper the Doctor | Tony Tony Chopper | editor | Diagnoses problems and heals the content — fixes what's broken |
-| Robin the Scholar | Nico Robin | fact-checker | Archaeologist who deciphers truth from history and sources |
-| Franky the Shipwright | Franky | publisher-release | Builds and maintains the ship — packaging, deployment, CI |
-| Brook the Musician | Brook | seo-expert | Brings life and rhythm to content — SEO, discoverability, audience reach |
-| Jinbe the Helmsman | Jinbe | historical-post-editor | Steady hand that steers legacy content through safe waters without capsizing |
+| Agent Name            | One Piece Character | Role                     | Rationale                                                                    |
+| --------------------- | ------------------- | ------------------------ | ---------------------------------------------------------------------------- |
+| Luffy the Captain     | Monkey D. Luffy     | team-lead / orchestrator | Captain who sets direction and delegates to the crew                         |
+| Zoro the Swordsman    | Roronoa Zoro        | developer                | First mate — cuts through problems with raw skill and discipline             |
+| Nami the Navigator    | Nami                | researcher               | Charts the course — finds information, maps the territory                    |
+| Sanji the Cook        | Sanji               | writer                   | Crafts something nourishing from raw ingredients — turns research into prose |
+| Chopper the Doctor    | Tony Tony Chopper   | editor                   | Diagnoses problems and heals the content — fixes what's broken               |
+| Robin the Scholar     | Nico Robin          | fact-checker             | Archaeologist who deciphers truth from history and sources                   |
+| Franky the Shipwright | Franky              | publisher-release        | Builds and maintains the ship — packaging, deployment, CI                    |
+| Brook the Musician    | Brook               | seo-expert               | Brings life and rhythm to content — SEO, discoverability, audience reach     |
+| Jinbe the Helmsman    | Jinbe               | historical-post-editor   | Steady hand that steers legacy content through safe waters without capsizing |
 
 Agent names follow the format `<Name> the <Role>`. These names are used in Codex `config.toml` agent definitions, skill descriptions, prompt headers, and Slack notifications for personality and quick identification.
 
@@ -916,6 +963,7 @@ The naming convention is extensible. New agents (including reasoning agents) fol
 #### Loop prevention
 
 If an agent attempts the same action 3 times with the same inputs and gets the same result, it MUST stop immediately. The agent MUST:
+
 1. Summarize what was attempted and what failed.
 2. Post the summary as a comment on the Linear issue.
 3. Set the issue status to `Blocked`.
@@ -926,6 +974,7 @@ For scripts: All retry-capable scripts in `scripts/` MUST include a retry counte
 #### Stuck-agent escalation
 
 If an agent cannot make progress for any reason (missing file, permission error, ambiguous requirement), it MUST:
+
 1. Stop work immediately.
 2. Write a comment on the Linear issue describing the blocker.
 3. Post a notification to `#codex-runs` via Slack webhook.
@@ -945,7 +994,8 @@ max_depth = 1
 - **max_depth = 1**: Sub-agents MUST NOT spawn their own sub-agents. Only the orchestrator (Luffy) delegates.
 
 The orchestrator skill MUST include:
-```
+
+```text
 CONCURRENCY LIMIT: Never delegate more than 3 parallel agents.
 If the plan has more than 3 parallel lanes, batch them:
 - Turn 1: Launch lanes 1-3, wait for results.
@@ -957,7 +1007,7 @@ If the plan has more than 3 parallel lanes, batch them:
 
 Each agent is defined by three layers, separating identity, behavior, and function:
 
-```
+```text
 .codex/agents/<agent-name>/
 ├── config.toml          # Functional: tools, permissions, model assignment
 ├── soul.md              # Behavioral: identity, values, guardrails, personality
@@ -974,15 +1024,17 @@ Example `soul.md` for Zoro the Swordsman (developer):
 You are Zoro the Swordsman — disciplined, direct, and relentless.
 
 ## Values
+
 - Precision over speed. Measure twice, cut once.
 - Tests come before code. Always.
 - Your scope is your boundary. Stay in your lane.
 
 ## Guardrails
+
 - You MUST NOT start coding until tests are written.
 - You MUST NOT touch files outside your assigned scope.
 - You MUST NOT merge or approve PRs — only create them.
-- You MUST NOT modify editorial content (_posts/, _drafts/, _pages/).
+- You MUST NOT modify editorial content (\_posts/, \_drafts/, \_pages/).
 - If you're stuck, you report the obstacle — you MUST NOT hack around it.
 ```
 
@@ -990,7 +1042,8 @@ You are Zoro the Swordsman — disciplined, direct, and relentless.
 
 ```markdown
 ## Boundaries
-- MUST NOT modify: _posts/, _drafts/, _pages/, docs/editorial/
+
+- MUST NOT modify: \_posts/, \_drafts/, \_pages/, docs/editorial/
 - MUST NOT run: make publish-draft, make qa-publish, make finalize-merge
 - MUST NOT merge, approve, or close PRs
 - MUST NOT modify AGENTS.md, config.toml, or other agent configs
@@ -1001,17 +1054,17 @@ Each agent role gets its own boundary set. See the full boundary matrix below.
 
 #### Agent Boundary Matrix
 
-| Agent | MUST NOT modify | MUST NOT run | Special restrictions |
-|---|---|---|---|
-| Zoro (developer) | _posts/, _drafts/, _pages/, docs/editorial/ | make publish-draft, make qa-publish | MUST NOT touch editorial content |
-| Sanji (writer) | scripts/, .github/, Makefile, config files | make setup, make ci-setup | MUST NOT touch infrastructure |
-| Chopper (editor) | scripts/, .github/, Makefile, config files | make setup, make ci-setup | MUST NOT touch infrastructure |
-| Robin (fact-checker) | ALL files (read-only) | Any write commands | MUST NOT modify any file — only report findings |
-| Nami (researcher) | ALL files (read-only) | Any write commands | MUST NOT modify any file — only report findings |
-| Franky (publisher) | _posts/ content, _drafts/ content | N/A | MUST NOT change post body prose — only packaging/CI |
-| Brook (SEO) | scripts/, .github/, Makefile | make setup | MUST NOT touch infrastructure |
-| Jinbe (historical editor) | scripts/, .github/, Makefile, config files | make setup, make ci-setup | MUST NOT change original publish dates |
-| Luffy (orchestrator) | Direct file modifications | Direct implementation commands | MUST delegate, MUST NOT execute directly |
+| Agent                     | MUST NOT modify                                | MUST NOT run                        | Special restrictions                                |
+| ------------------------- | ---------------------------------------------- | ----------------------------------- | --------------------------------------------------- |
+| Zoro (developer)          | \_posts/, \_drafts/, \_pages/, docs/editorial/ | make publish-draft, make qa-publish | MUST NOT touch editorial content                    |
+| Sanji (writer)            | scripts/, .github/, Makefile, config files     | make setup, make ci-setup           | MUST NOT touch infrastructure                       |
+| Chopper (editor)          | scripts/, .github/, Makefile, config files     | make setup, make ci-setup           | MUST NOT touch infrastructure                       |
+| Robin (fact-checker)      | ALL files (read-only)                          | Any write commands                  | MUST NOT modify any file — only report findings     |
+| Nami (researcher)         | ALL files (read-only)                          | Any write commands                  | MUST NOT modify any file — only report findings     |
+| Franky (publisher)        | \_posts/ content, \_drafts/ content            | N/A                                 | MUST NOT change post body prose — only packaging/CI |
+| Brook (SEO)               | scripts/, .github/, Makefile                   | make setup                          | MUST NOT touch infrastructure                       |
+| Jinbe (historical editor) | scripts/, .github/, Makefile, config files     | make setup, make ci-setup           | MUST NOT change original publish dates              |
+| Luffy (orchestrator)      | Direct file modifications                      | Direct implementation commands      | MUST delegate, MUST NOT execute directly            |
 
 ### Required prompt set
 
@@ -1030,6 +1083,7 @@ Each agent role gets its own boundary set. See the full boundary matrix below.
 #### Manual judgment prompts
 
 Create:
+
 - `.codex/prompts/editorial-checks/audience-check.md`
 - `.codex/prompts/editorial-checks/fact-check.md`
 - `.codex/prompts/editorial-checks/authority-check.md`
@@ -1068,6 +1122,7 @@ Once the plan is approved (Shabib re-invokes Codex with "Plan approved, proceed"
 #### Prompt requirements
 
 Every orchestrator prompt MUST:
+
 - Read the brief from `docs/tasks/CWS-NNN.md` (path provided at Codex start)
 - Read `docs/agent-context.md` for project state
 - Define agent sequence with explicit role assignments
@@ -1096,6 +1151,7 @@ New posts MUST be created in `_drafts/` first and only moved to `_posts/` after 
 #### Special constraint for editorial-update
 
 The agent MUST NOT:
+
 - Change body prose
 - Change original publish date
 - Use the workflow for substantive rewrites
@@ -1119,13 +1175,14 @@ Before creating the PR, the orchestrator MUST verify all of the following. If an
 
 ## Agent Context System
 
-### Purpose
+### Agent context purpose
 
 Codex agents have no cross-session memory. Each task starts from scratch. To provide project continuity, agents read and update a persistent context file.
 
 ### File: `docs/agent-context.md`
 
 Format: **Markdown** (not JSON/JSONL). Rationale:
+
 - Codex agents read markdown natively — consistent with AGENTS.md, SKILL.md, and task files.
 - Human-readable and human-editable for periodic review.
 - Clean git diffs for PR review.
@@ -1135,23 +1192,29 @@ Format: **Markdown** (not JSON/JSONL). Rationale:
 
 ```markdown
 # Agent Context — CodeWithShabib
+
 _Last updated: YYYY-MM-DD by [agent-name] during CWS-NNN_
 
 ## Current Focus
+
 - [3-5 bullet points of active workstreams]
 
 ## Recent Decisions
+
 - [ADR references, recent architectural choices with brief rationale]
 
 ## Known Constraints
+
 - [Free tier limits, tooling quirks, unresolved issues, blockers]
 
 ## Editorial State
+
 - Posts in draft: [list]
 - Recently published: [list]
 - Scheduled: [list]
 
 ## Open Questions
+
 - [Anything unresolved that the next agent should be aware of]
 ```
 
@@ -1162,7 +1225,7 @@ _Last updated: YYYY-MM-DD by [agent-name] during CWS-NNN_
 - Updates are committed as part of the task branch — reviewed in the PR like any other change.
 - Shabib reviews the context file periodically and corrects any drift.
 - Add to `AGENTS.md`:
-  ```
+  ```text
   Before starting any task, read docs/agent-context.md for project context.
   After completing a task, update the relevant section if anything changed.
   ```
@@ -1171,28 +1234,29 @@ _Last updated: YYYY-MM-DD by [agent-name] during CWS-NNN_
 
 ## Reasoning Agent System
 
-### Purpose
+### Reasoning agent purpose
 
 Reasoning agents apply structured mental models to improve decision quality across all workflows. They can be invoked:
+
 - As **Codex skills** in the repo (via `$skill-name` in the Codex app/CLI)
 - As **portable prompt templates** from Perplexity or ChatGPT (iOS, Android, Mac, web) for general thinking outside the repo
 - **Automatically by the orchestrator** when the task context warrants specific reasoning patterns
 
 ### Mental Model Skills
 
-| Skill Name | Mental Model | When to Use | One Piece Name |
-|---|---|---|---|
-| `$first-principles` | First Principles Thinking | Decompose a problem to its fundamental truths before building up | Vegapunk the Scientist |
-| `$second-order` | Second-Order Thinking | Evaluate consequences of consequences before committing | Shanks the Strategist |
-| `$socratic` | Socratic Questioning | Challenge assumptions through systematic questioning | Rayleigh the Mentor |
-| `$red-team` | Red Teaming / Devil's Advocate | Actively find flaws, attack the plan, stress-test assumptions | Mihawk the Rival |
-| `$inversion` | Inversion | Work backward from failure — what would make this fail? | Crocodile the Schemer |
-| `$pareto` | 80/20 (Pareto Principle) | Identify the 20% of effort that delivers 80% of value | Doflamingo the Puppeteer |
-| `$opportunity-cost` | Opportunity Cost | What are we giving up by choosing this path? | Garp the Veteran |
-| `$circle-of-competence` | Circle of Competence | Stay within what we know; identify when we're outside it | Whitebeard the Elder |
-| `$margin-of-safety` | Margin of Safety | Build buffers against what can go wrong | Kuma the Protector |
-| `$feedback-loop` | Feedback Loops | Identify reinforcing and balancing loops in the system | Katakuri the Predictor |
-| `$bayesian` | Bayesian Updating | Update beliefs based on new evidence; avoid anchoring | Dragon the Revolutionary |
+| Skill Name              | Mental Model                   | When to Use                                                      | One Piece Name           |
+| ----------------------- | ------------------------------ | ---------------------------------------------------------------- | ------------------------ |
+| `$first-principles`     | First Principles Thinking      | Decompose a problem to its fundamental truths before building up | Vegapunk the Scientist   |
+| `$second-order`         | Second-Order Thinking          | Evaluate consequences of consequences before committing          | Shanks the Strategist    |
+| `$socratic`             | Socratic Questioning           | Challenge assumptions through systematic questioning             | Rayleigh the Mentor      |
+| `$red-team`             | Red Teaming / Devil's Advocate | Actively find flaws, attack the plan, stress-test assumptions    | Mihawk the Rival         |
+| `$inversion`            | Inversion                      | Work backward from failure — what would make this fail?          | Crocodile the Schemer    |
+| `$pareto`               | 80/20 (Pareto Principle)       | Identify the 20% of effort that delivers 80% of value            | Doflamingo the Puppeteer |
+| `$opportunity-cost`     | Opportunity Cost               | What are we giving up by choosing this path?                     | Garp the Veteran         |
+| `$circle-of-competence` | Circle of Competence           | Stay within what we know; identify when we're outside it         | Whitebeard the Elder     |
+| `$margin-of-safety`     | Margin of Safety               | Build buffers against what can go wrong                          | Kuma the Protector       |
+| `$feedback-loop`        | Feedback Loops                 | Identify reinforcing and balancing loops in the system           | Katakuri the Predictor   |
+| `$bayesian`             | Bayesian Updating              | Update beliefs based on new evidence; avoid anchoring            | Dragon the Revolutionary |
 
 ### Invocation modes
 
@@ -1208,6 +1272,7 @@ Reasoning agents apply structured mental models to improve decision quality acro
 ### Skill file structure
 
 Each reasoning skill lives at `.agents/skills/<skill-name>/SKILL.md` with:
+
 - Clear trigger description (when Codex should auto-select)
 - The mental model definition
 - Step-by-step reasoning protocol
@@ -1221,6 +1286,7 @@ Each mental model also has a companion prompt template at `.codex/docs/reasoning
 ### Files to create
 
 Under `.agents/skills/`:
+
 - `first-principles/SKILL.md`
 - `second-order/SKILL.md`
 - `socratic/SKILL.md`
@@ -1234,6 +1300,7 @@ Under `.agents/skills/`:
 - `bayesian/SKILL.md`
 
 Under `.codex/docs/reasoning-prompts/`:
+
 - `first-principles.md`
 - `second-order.md`
 - `socratic.md`
@@ -1265,13 +1332,13 @@ The dispatch workflow is a cheap prep step, not an execution engine. It automate
 
 ### Triggering the dispatch
 
-| Surface | Method |
-|---|---|
-| Perplexity (iOS/Android/Mac/web) | GitHub connector → trigger workflow_dispatch |
-| ChatGPT (iOS/Android/Mac/web) | Not directly supported for workflow_dispatch; use Codex Cloud to create a task that calls `gh workflow run`, or ask Shabib to trigger via CLI |
-| CLI (terminal) | `gh workflow run codex-dispatch.yml -f issue_id=CWS-42 -f workflow_type=dev` |
-| GitHub UI | Actions tab → codex-dispatch → Run workflow |
-| GitHub REST API | `POST /repos/{owner}/{repo}/actions/workflows/codex-dispatch.yml/dispatches` |
+| Surface                          | Method                                                                                                                                        |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Perplexity (iOS/Android/Mac/web) | GitHub connector → trigger workflow_dispatch                                                                                                  |
+| ChatGPT (iOS/Android/Mac/web)    | Not directly supported for workflow_dispatch; use Codex Cloud to create a task that calls `gh workflow run`, or ask Shabib to trigger via CLI |
+| CLI (terminal)                   | `gh workflow run codex-dispatch.yml -f issue_id=CWS-42 -f workflow_type=dev`                                                                  |
+| GitHub UI                        | Actions tab → codex-dispatch → Run workflow                                                                                                   |
+| GitHub REST API                  | `POST /repos/{owner}/{repo}/actions/workflows/codex-dispatch.yml/dispatches`                                                                  |
 
 > **March 2026 update:** The GitHub workflow_dispatch API now returns `run_id` in the response when `return_run_details=true` is passed, making it possible to track the dispatch run programmatically.
 
@@ -1286,9 +1353,11 @@ The dispatch workflow is a cheap prep step, not an execution engine. It automate
 ### Secret policy
 
 Document required secrets in:
+
 - `.codex/docs/secrets.md`
 
 Required secrets:
+
 - `LINEAR_API_KEY` — for fetching issue content in dispatch workflow
 - `SLACK_WEBHOOK_URL` — for CI and dispatch Slack notifications
 - `OPENAI_API_KEY` — only if using `openai/codex-action@v1` for PR review; scoped to that workflow
@@ -1306,6 +1375,7 @@ Three setup targets, all driven through the Makefile:
 ### `make setup` — New Mac bootstrap
 
 Must handle:
+
 - Verify Homebrew, Ruby, Bundler, Node (for markdownlint)
 - `bundle install` for Jekyll + gems
 - `gh` CLI auth check
@@ -1319,6 +1389,7 @@ Must handle:
 ### `make ci-setup` — GitHub Actions runner bootstrap
 
 Runs in CI workflows as a first step. Must handle:
+
 - Ruby + Bundler install (via setup-ruby action)
 - Node install if needed (via setup-node action)
 - `bundle install --jobs 4 --retry 3`
@@ -1328,6 +1399,7 @@ Runs in CI workflows as a first step. Must handle:
 ### `make codex-setup` — Codex environment verification
 
 Run at the start of a Codex session to verify the agent has what it needs:
+
 - Verify `AGENTS.md` exists and is under 32 KiB
 - Verify required skills are present
 - Verify Makefile targets are accessible
@@ -1351,13 +1423,13 @@ Run at the start of a Codex session to verify the agent has what it needs:
 
 ### Integration budget (10 slots)
 
-| # | Integration | Purpose |
-|---|---|---|
-| 1 | **Linear** | Issue creation from Slack, status updates, bidirectional comment sync |
-| 2 | **GitHub** | PR notifications, merge alerts, CI status |
-| 3 | **Incoming Webhooks** | Custom notifications from CI workflows (dispatch ready, merge, failures) |
-| 4 | **Perplexity Computer** | AI agent tasks from Slack (already connected) |
-| 5-10 | Reserved | Future integrations as needed |
+| #    | Integration             | Purpose                                                                  |
+| ---- | ----------------------- | ------------------------------------------------------------------------ |
+| 1    | **Linear**              | Issue creation from Slack, status updates, bidirectional comment sync    |
+| 2    | **GitHub**              | PR notifications, merge alerts, CI status                                |
+| 3    | **Incoming Webhooks**   | Custom notifications from CI workflows (dispatch ready, merge, failures) |
+| 4    | **Perplexity Computer** | AI agent tasks from Slack (already connected)                            |
+| 5-10 | Reserved                | Future integrations as needed                                            |
 
 > **Important:** Graphite → Slack integration requires the Starter tier ($20/user/month) and is **not available on the free plan**. All PR/stack notifications should go through GitHub Actions → Slack webhooks instead.
 
@@ -1402,6 +1474,7 @@ Run at the start of a Codex session to verify the agent has what it needs:
 ### Supporting docs
 
 Add:
+
 - `.codex/docs/tools.md`
 - `.codex/docs/slack-setup.md`
 - `.codex/docs/secrets.md`
@@ -1417,6 +1490,7 @@ This system is intentionally architectural: agent workflows, CI design, cost con
 ### Directory
 
 Create:
+
 - `docs/adr/README.md`
 - `docs/adr/template.md`
 - `docs/adr/0001-use-jekyll-github-pages.md`
@@ -1424,14 +1498,17 @@ Create:
 ### Helper
 
 Create:
+
 - `scripts/new-adr.sh`
 
 Expose via:
+
 - `make new-adr TITLE="..."`
 
 ### ADR-triggering changes
 
 If a PR touches:
+
 - `.codex/**`
 - `.agents/**`
 - `.github/workflows/**`
@@ -1449,6 +1526,7 @@ Create these projects:
 ### 1. `[INFRA] Repo Process & Tooling`
 
 Purpose:
+
 - hooks
 - CI split
 - TDD system
@@ -1462,6 +1540,7 @@ Purpose:
 ### 2. `[ORCHESTRATION] Agentic Workflow Design`
 
 Purpose:
+
 - Linear intake templates
 - workflow dispatch
 - per-task file system (`docs/tasks/CWS-NNN.md`)
@@ -1474,6 +1553,7 @@ Purpose:
 ### 3. `[EDITORIAL] Content Quality System`
 
 Purpose:
+
 - automated content checks
 - judgment prompts
 - voice profile
@@ -1485,11 +1565,12 @@ Purpose:
 
 ## Linear Task Breakdown Strategy
 
-**How to break the Master Plan into Linear work:**
+How to break the Master Plan into Linear work:
 
-**Epic structure (3 projects, each with epics):**
+Epic structure (3 projects, each with epics):
 
 Project: [INFRA] Repo Process & Tooling
+
 - Epic: DX Setup & Bootstrap
 - Epic: CI Pipeline Architecture
 - Epic: Security Guardrails
@@ -1498,6 +1579,7 @@ Project: [INFRA] Repo Process & Tooling
 - Epic: ADR System
 
 Project: [ORCHESTRATION] Agentic Workflow Design
+
 - Epic: AGENTS.md & Codex Config
 - Epic: Skill Authoring (agentskills.io compliant)
 - Epic: Reasoning Agent Skills (mental models)
@@ -1506,12 +1588,14 @@ Project: [ORCHESTRATION] Agentic Workflow Design
 - Epic: Definition of Ready & Done
 
 Project: [EDITORIAL] Content Quality System
+
 - Epic: Editorial QA Pipeline
 - Epic: Publish-Draft Workflow
 - Epic: Historical Post Updates
 - Epic: Site Audit Automation
 
-**Breakdown rules:**
+Breakdown rules:
+
 1. Each epic maps to a section of this Master Plan.
 2. Each task under an epic maps to ONE bounded deliverable (a script, a workflow file, a skill, a doc, a Makefile target).
 3. Tasks are labeled `agent-task` or `human-task`.
@@ -1568,9 +1652,10 @@ This section summarizes the implementation backlog at epic level.
   - Two-phase orchestrator design (plan → approve → execute)
   - Clarification protocol in orchestrator skill
   - Plan review gate (Option C: Linear comment + Slack notification)
-10. Build 11 mental model reasoning skills (`.agents/skills/`)
-11. Write 11 portable reasoning prompt templates (`.codex/docs/reasoning-prompts/`)
-12. Create reasoning agent orchestration rules (when to auto-invoke which models)
+
+1. Build 11 mental model reasoning skills (`.agents/skills/`)
+2. Write 11 portable reasoning prompt templates (`.codex/docs/reasoning-prompts/`)
+3. Create reasoning agent orchestration rules (when to auto-invoke which models)
 
 ### EDITORIAL epics
 
@@ -1618,6 +1703,7 @@ This section summarizes the implementation backlog at epic level.
 ### New agent config files
 
 For each agent (zoro, sanji, chopper, robin, nami, franky, brook, jinbe, luffy):
+
 - `.codex/agents/<agent-name>/config.toml`
 - `.codex/agents/<agent-name>/soul.md`
 - `.codex/agents/<agent-name>/instructions.md`
@@ -1698,25 +1784,25 @@ For each agent (zoro, sanji, chopper, robin, nami, franky, brook, jinbe, luffy):
 
 ## Human vs Agent Responsibility Matrix
 
-| Area | Human | Agent | Notes |
-|---|---|---|---|
-| Linear project setup | Yes | No | Workspace/admin task |
-| Label taxonomy | Yes | No | Best created deliberately |
-| Slack workspace creation | Yes | No | Human account creation required |
-| Slack integration wiring docs | Yes | Yes | Human does setup, agent can document |
-| `.gitignore` fix for `_drafts/` | Review | Yes | Agent-friendly, human verifies |
-| Prompt writing | Hybrid | Yes | Human sets policy, agent drafts structure |
-| Hook implementation | Review | Yes | Agent-friendly |
-| Test writing | Review | Yes | Must be test-first |
-| Editorial voice policy | Yes | Assist only | Human source of truth |
-| Authority rubric | Yes | Assist only | Human judgment framework |
-| ADR policy | Yes | Assist only | Human-owned architecture decisions |
-| CI YAML implementation | Review | Yes | Agent-friendly |
-| Dispatch workflow | Review | Yes | Agent implements, human reviews |
-| Per-task file template | Hybrid | Yes | Human defines structure, agent implements |
-| Trigger surface guide | Yes | Assist only | Human documents actual usage patterns |
-| Final editorial merge decision | Yes | No | Human-only |
-| Final architecture merge decision | Yes | No | Human-only |
+| Area                              | Human  | Agent       | Notes                                     |
+| --------------------------------- | ------ | ----------- | ----------------------------------------- |
+| Linear project setup              | Yes    | No          | Workspace/admin task                      |
+| Label taxonomy                    | Yes    | No          | Best created deliberately                 |
+| Slack workspace creation          | Yes    | No          | Human account creation required           |
+| Slack integration wiring docs     | Yes    | Yes         | Human does setup, agent can document      |
+| `.gitignore` fix for `_drafts/`   | Review | Yes         | Agent-friendly, human verifies            |
+| Prompt writing                    | Hybrid | Yes         | Human sets policy, agent drafts structure |
+| Hook implementation               | Review | Yes         | Agent-friendly                            |
+| Test writing                      | Review | Yes         | Must be test-first                        |
+| Editorial voice policy            | Yes    | Assist only | Human source of truth                     |
+| Authority rubric                  | Yes    | Assist only | Human judgment framework                  |
+| ADR policy                        | Yes    | Assist only | Human-owned architecture decisions        |
+| CI YAML implementation            | Review | Yes         | Agent-friendly                            |
+| Dispatch workflow                 | Review | Yes         | Agent implements, human reviews           |
+| Per-task file template            | Hybrid | Yes         | Human defines structure, agent implements |
+| Trigger surface guide             | Yes    | Assist only | Human documents actual usage patterns     |
+| Final editorial merge decision    | Yes    | No          | Human-only                                |
+| Final architecture merge decision | Yes    | No          | Human-only                                |
 
 ---
 
@@ -1781,70 +1867,70 @@ This plan is complete when all of the following are true:
 
 ## Appendix A: Tool Capabilities Matrix (March 2026)
 
-| Tool | Surfaces | Key Capabilities | Free Tier Limits |
-|---|---|---|---|
-| **Perplexity** | iOS, Android, Mac, Web | Research, Linear connector, GitHub connector, Slack connector | Pro Search limits on free; connectors require Pro/Max |
-| **ChatGPT** | iOS, Android, Mac, Web | Conversation, Codex Cloud sidebar, GitHub read-only app | Codex included with Plus+ |
-| **Codex CLI** | macOS (user), Linux (CI-only) | Local agent, multi-agent (experimental), MCP server, open-source | Included with ChatGPT subscription |
-| **Codex App** | macOS | Multi-agent management, worktrees, automations, skills | Included with ChatGPT subscription |
-| **Codex IDE Extension** | VS Code, Cursor, Windsurf, JetBrains | In-IDE agent, Cloud delegation | Included with ChatGPT subscription |
-| **Codex Cloud** | Web (chatgpt.com/codex), ChatGPT iOS/Android | Remote sandboxed execution, PR creation | Included with ChatGPT subscription |
-| **Codex GitHub Action** | CI | `openai/codex-action@v1`, PR review, patch application | Requires API key |
-| **Linear** | Web, iOS, Android, Mac | GraphQL API, GitHub integration (free), Slack integration (free) | Free plan: unlimited issues |
-| **Graphite** | CLI, VS Code, Web | Stacked PRs, PR inbox, limited AI reviews | Hobby: personal repos, CLI, no Slack, no merge queue |
-| **GitHub Actions** | CI | `workflow_dispatch` (API returns `run_id` since Feb 2026), path filtering | Free for public repos; 2000 min/month private |
-| **Slack** | iOS, Android, Mac, Web | Channels, webhooks, app integrations | Free: 90-day history, 10 integrations, 5 GB storage |
-| **Jekyll** | Build tool | `_drafts/` ignored in prod by default, `--drafts` flag for local preview | N/A |
+| Tool                    | Surfaces                                     | Key Capabilities                                                          | Free Tier Limits                                      |
+| ----------------------- | -------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------- |
+| **Perplexity**          | iOS, Android, Mac, Web                       | Research, Linear connector, GitHub connector, Slack connector             | Pro Search limits on free; connectors require Pro/Max |
+| **ChatGPT**             | iOS, Android, Mac, Web                       | Conversation, Codex Cloud sidebar, GitHub read-only app                   | Codex included with Plus+                             |
+| **Codex CLI**           | macOS (user), Linux (CI-only)                | Local agent, multi-agent (experimental), MCP server, open-source          | Included with ChatGPT subscription                    |
+| **Codex App**           | macOS                                        | Multi-agent management, worktrees, automations, skills                    | Included with ChatGPT subscription                    |
+| **Codex IDE Extension** | VS Code, Cursor, Windsurf, JetBrains         | In-IDE agent, Cloud delegation                                            | Included with ChatGPT subscription                    |
+| **Codex Cloud**         | Web (chatgpt.com/codex), ChatGPT iOS/Android | Remote sandboxed execution, PR creation                                   | Included with ChatGPT subscription                    |
+| **Codex GitHub Action** | CI                                           | `openai/codex-action@v1`, PR review, patch application                    | Requires API key                                      |
+| **Linear**              | Web, iOS, Android, Mac                       | GraphQL API, GitHub integration (free), Slack integration (free)          | Free plan: unlimited issues                           |
+| **Graphite**            | CLI, VS Code, Web                            | Stacked PRs, PR inbox, limited AI reviews                                 | Hobby: personal repos, CLI, no Slack, no merge queue  |
+| **GitHub Actions**      | CI                                           | `workflow_dispatch` (API returns `run_id` since Feb 2026), path filtering | Free for public repos; 2000 min/month private         |
+| **Slack**               | iOS, Android, Mac, Web                       | Channels, webhooks, app integrations                                      | Free: 90-day history, 10 integrations, 5 GB storage   |
+| **Jekyll**              | Build tool                                   | `_drafts/` ignored in prod by default, `--drafts` flag for local preview  | N/A                                                   |
 
 ---
 
 ## Appendix B: Change Log
 
-| # | Change | Reason |
-|---|---|---|
-| 1 | `_drafts/` must be tracked by git | Agents need to create/edit drafts in branches; currently gitignored |
-| 2 | All trigger surfaces expanded to iOS + Android + Mac + Web | Perplexity and ChatGPT available on all four surfaces |
-| 3 | Codex surfaces documented (CLI, Mac App, IDE Extension, Cloud) | All surfaces are available as of March 2026 |
-| 4 | `CODEX_TASK.md` replaced with per-task `docs/tasks/CWS-NNN.md` | Per-task files avoid conflicts, provide history, map to Linear issues |
-| 5 | Human-in-the-loop reduced to two touchpoints | Idea creation and final review; everything else automated |
-| 6 | Codex start remains manual (no API) | No programmatic trigger API exists as of March 2026 |
-| 7 | Slack 10-integration budget documented | Free plan hard limit; integration slots must be planned |
-| 8 | Graphite free tier constraints documented | Slack integration, merge queue, and org repos require paid tiers |
-| 9 | ChatGPT GitHub integration clarified as read-only | Cannot trigger workflow_dispatch; Codex or CLI needed for writes |
-| 10 | GitHub workflow_dispatch API `return_run_details` noted | Feb 2026 change enables tracking dispatch runs |
-| 11 | Codex GitHub Action (`openai/codex-action@v1`) added as optional CI tool | Available for PR review without running full agent tasks |
-| 12 | Editorial pipeline triggers expanded to include `_drafts/**` | Drafts need the same validation as published posts |
-| 13 | iOS-intake-guide replaced with multi-surface trigger guide | Covers all surfaces, not just iOS |
-| 14 | Codex usage doc scoped to macOS surfaces (Linux = CI-only) | CLI, Mac app, IDE extension, Cloud |
-| 15 | Tool capabilities matrix added as Appendix A | Quick reference for all tool constraints validated against March 2026 docs |
-| 16 | Windows references removed | User does not use Windows; reduces noise |
-| 17 | One Piece agent naming system added | Agents get memorable identities matching their roles |
-| 18 | Mental model reasoning agents added | 11 structured thinking skills as Codex skills + portable prompts |
-| 19 | Master Plan storage location defined | `docs/master-plan.md` in repo (authoritative) + Linear reference copy |
-| 20 | Reasoning agent auto-invocation rules added | Orchestrator can intelligently apply mental models based on task context |
-| 21 | Explicit device profile added (v3.1) | Mac + iPhone + Android phone + Linux (CI-only). No Windows. |
-| 22 | Android added to all mobile surface references | Perplexity, ChatGPT, Linear, Slack, Codex Cloud sidebar |
-| 23 | Codex CLI/IDE Linux clarified as CI-only | User runs Codex CLI on macOS; Linux only appears in GitHub-hosted runners |
-| 24 | Trigger surfaces expanded to iOS + Android + Mac + Web | Both mobile OSes Shabib uses are now represented |
-| 25 | Scripting language policy documented | Bash default, Ruby for Jekyll/YAML; Makefile is single entry point |
-| 26 | One-shot DX setup targets defined | `make setup`, `make ci-setup`, `make codex-setup` |
-| 27 | Definition of Ready added | 8-point checklist gating agent task pickup |
-| 28 | Linear API key necessity clarified | Needed only for dispatch workflow CI; free personal API key |
-| 29 | Semgrep CE + CodeQL added as first-class security guardrails | Free SAST tools, blocking on PRs |
-| 30 | Linear task breakdown strategy added | Epic structure, breakdown rules, execution order |
-| 31 | Known gaps and risks section added | 9 blind spots documented with mitigations |
-| 32 | Definition of Done updated | `make security` added alongside `make check` |
-| 33 | DeerFlow-inspired agent safety rules added | Loop prevention, stuck-agent escalation, retry limits in scripts |
-| 34 | soul.md + instructions.md per agent | Separates identity/personality from operational boundaries |
-| 35 | MUST NOT language adopted for agent boundaries | Stronger than MAY NOT — unambiguous prohibition |
-| 36 | Agent boundary matrix added | Explicit per-role file and command restrictions |
-| 37 | Persistent agent context file (docs/agent-context.md) | Markdown-based cross-session memory for agents |
-| 38 | Two-phase orchestrator design | Plan phase (post to Linear, notify Slack) → approval → execute phase |
-| 39 | Option C plan review gate | Linear comment = permanent record, Slack notification = doorbell |
-| 40 | Structured clarification protocol | SCOPE/APPROACH/RISK/MISSING taxonomy for agent questions |
-| 41 | Self-audit checklist before PR creation | 10-point verification before any PR is opened |
-| 42 | Concurrency limits set (max_threads=3, max_depth=1) | Prevents coordination chaos in multi-agent execution |
-| 43 | Agent context system added to backlog | New epic under INFRA and ORCHESTRATION |
+| #   | Change                                                                   | Reason                                                                     |
+| --- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| 1   | `_drafts/` must be tracked by git                                        | Agents need to create/edit drafts in branches; currently gitignored        |
+| 2   | All trigger surfaces expanded to iOS + Android + Mac + Web               | Perplexity and ChatGPT available on all four surfaces                      |
+| 3   | Codex surfaces documented (CLI, Mac App, IDE Extension, Cloud)           | All surfaces are available as of March 2026                                |
+| 4   | `CODEX_TASK.md` replaced with per-task `docs/tasks/CWS-NNN.md`           | Per-task files avoid conflicts, provide history, map to Linear issues      |
+| 5   | Human-in-the-loop reduced to two touchpoints                             | Idea creation and final review; everything else automated                  |
+| 6   | Codex start remains manual (no API)                                      | No programmatic trigger API exists as of March 2026                        |
+| 7   | Slack 10-integration budget documented                                   | Free plan hard limit; integration slots must be planned                    |
+| 8   | Graphite free tier constraints documented                                | Slack integration, merge queue, and org repos require paid tiers           |
+| 9   | ChatGPT GitHub integration clarified as read-only                        | Cannot trigger workflow_dispatch; Codex or CLI needed for writes           |
+| 10  | GitHub workflow_dispatch API `return_run_details` noted                  | Feb 2026 change enables tracking dispatch runs                             |
+| 11  | Codex GitHub Action (`openai/codex-action@v1`) added as optional CI tool | Available for PR review without running full agent tasks                   |
+| 12  | Editorial pipeline triggers expanded to include `_drafts/**`             | Drafts need the same validation as published posts                         |
+| 13  | iOS-intake-guide replaced with multi-surface trigger guide               | Covers all surfaces, not just iOS                                          |
+| 14  | Codex usage doc scoped to macOS surfaces (Linux = CI-only)               | CLI, Mac app, IDE extension, Cloud                                         |
+| 15  | Tool capabilities matrix added as Appendix A                             | Quick reference for all tool constraints validated against March 2026 docs |
+| 16  | Windows references removed                                               | User does not use Windows; reduces noise                                   |
+| 17  | One Piece agent naming system added                                      | Agents get memorable identities matching their roles                       |
+| 18  | Mental model reasoning agents added                                      | 11 structured thinking skills as Codex skills + portable prompts           |
+| 19  | Master Plan storage location defined                                     | `docs/master-plan.md` in repo (authoritative) + Linear reference copy      |
+| 20  | Reasoning agent auto-invocation rules added                              | Orchestrator can intelligently apply mental models based on task context   |
+| 21  | Explicit device profile added (v3.1)                                     | Mac + iPhone + Android phone + Linux (CI-only). No Windows.                |
+| 22  | Android added to all mobile surface references                           | Perplexity, ChatGPT, Linear, Slack, Codex Cloud sidebar                    |
+| 23  | Codex CLI/IDE Linux clarified as CI-only                                 | User runs Codex CLI on macOS; Linux only appears in GitHub-hosted runners  |
+| 24  | Trigger surfaces expanded to iOS + Android + Mac + Web                   | Both mobile OSes Shabib uses are now represented                           |
+| 25  | Scripting language policy documented                                     | Bash default, Ruby for Jekyll/YAML; Makefile is single entry point         |
+| 26  | One-shot DX setup targets defined                                        | `make setup`, `make ci-setup`, `make codex-setup`                          |
+| 27  | Definition of Ready added                                                | 8-point checklist gating agent task pickup                                 |
+| 28  | Linear API key necessity clarified                                       | Needed only for dispatch workflow CI; free personal API key                |
+| 29  | Semgrep CE + CodeQL added as first-class security guardrails             | Free SAST tools, blocking on PRs                                           |
+| 30  | Linear task breakdown strategy added                                     | Epic structure, breakdown rules, execution order                           |
+| 31  | Known gaps and risks section added                                       | 9 blind spots documented with mitigations                                  |
+| 32  | Definition of Done updated                                               | `make security` added alongside `make check`                               |
+| 33  | DeerFlow-inspired agent safety rules added                               | Loop prevention, stuck-agent escalation, retry limits in scripts           |
+| 34  | soul.md + instructions.md per agent                                      | Separates identity/personality from operational boundaries                 |
+| 35  | MUST NOT language adopted for agent boundaries                           | Stronger than MAY NOT — unambiguous prohibition                            |
+| 36  | Agent boundary matrix added                                              | Explicit per-role file and command restrictions                            |
+| 37  | Persistent agent context file (docs/agent-context.md)                    | Markdown-based cross-session memory for agents                             |
+| 38  | Two-phase orchestrator design                                            | Plan phase (post to Linear, notify Slack) → approval → execute phase       |
+| 39  | Option C plan review gate                                                | Linear comment = permanent record, Slack notification = doorbell           |
+| 40  | Structured clarification protocol                                        | SCOPE/APPROACH/RISK/MISSING taxonomy for agent questions                   |
+| 41  | Self-audit checklist before PR creation                                  | 10-point verification before any PR is opened                              |
+| 42  | Concurrency limits set (max_threads=3, max_depth=1)                      | Prevents coordination chaos in multi-agent execution                       |
+| 43  | Agent context system added to backlog                                    | New epic under INFRA and ORCHESTRATION                                     |
 
 ---
 
@@ -1879,6 +1965,7 @@ Blind spots identified:
 This system is intentionally designed as a solo-human / multi-agent operating model.
 
 Shabib is not trying to automate away judgment. He is trying to automate away repetitive coordination, setup, validation, and mechanical execution so that his time is spent on:
+
 - architectural judgment
 - technical direction
 - editorial standards
@@ -1887,5 +1974,3 @@ Shabib is not trying to automate away judgment. He is trying to automate away re
 That is the correct role split.
 
 The two human touchpoints — idea creation and final review — are non-negotiable. Everything between them should require zero manual intervention except the current limitation of manually starting Codex (which may be resolved when OpenAI ships a programmatic trigger API).
-
-<!-- markdownlint-enable MD024 MD029 MD031 MD032 MD036 MD037 MD040 MD060 -->


### PR DESCRIPTION
## Summary

- Clean up markdownlint findings in `docs/master-plan.md`
- Normalize heading and list formatting for stable lint behavior
- Keep documentation intent unchanged while reducing style noise

## Why

- Keep governance docs consistently lint-clean and easier to maintain

## Rollout Metadata

- plan_id: `governance-v3`
- branch_mode: `task`
- phase: `n/a`
- required_checks: `build,semgrep,rollout-governance`

## Validation

- `make qa-local`

## Affected Files

```text
.codex/config.toml
docs/master-plan.md
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
