### PR TITLE
fix(cws-65): continue create-pr flow when gt restack fails

### DIFF
--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -191,9 +191,12 @@ if command -v gt >/dev/null 2>&1; then
   gt track --parent "$base_branch" >/dev/null 2>&1 || true
   if ! gt submit --stack --no-interactive >"$gt_log_file" 2>&1; then
     if grep -q "must restack before submitting this stack" "$gt_log_file"; then
-      gt restack
-      if ! gt submit --stack --no-interactive; then
+      if ! gt restack >>"$gt_log_file" 2>&1; then
+        echo "warning: gt restack failed; falling back to gh PR flow" >&2
+        cat "$gt_log_file" >&2
+      elif ! gt submit --stack --no-interactive >>"$gt_log_file" 2>&1; then
         echo "warning: gt submit failed after restack; falling back to gh PR flow" >&2
+        cat "$gt_log_file" >&2
       fi
     else
       echo "warning: gt submit failed; falling back to gh PR flow" >&2

--- a/scripts/tests/create_pr_workflow_test.rb
+++ b/scripts/tests/create_pr_workflow_test.rb
@@ -34,4 +34,14 @@ class CreatePrWorkflowTest < Minitest::Test
     assert_match(/warning: gt submit failed; falling back to gh PR flow/, script_body)
     refute_match(/error: gt submit failed/, script_body)
   end
+
+  def test_graphite_restack_failure_falls_back_to_gh_flow
+    assert_match(/if ! gt restack >>"\$gt_log_file" 2>&1; then/, script_body)
+    assert_match(/warning: gt restack failed; falling back to gh PR flow/, script_body)
+  end
+
+  def test_graphite_restack_failure_logs_context
+    assert_match(/if ! gt restack >>"\$gt_log_file" 2>&1; then/, script_body)
+    assert_match(/cat "\$gt_log_file" >&2/, script_body)
+  end
 end


### PR DESCRIPTION
## Summary

- Add fallback behavior in `scripts/create-pr.sh` when `gt restack` fails
- Continue PR creation flow after logging the restack failure instead of aborting
- Add workflow coverage in `scripts/tests/create_pr_workflow_test.rb`

## Why

- Improve resilience of PR creation automation when Graphite restack is flaky or unavailable

## Rollout Metadata

- plan_id: `governance-v3`
- branch_mode: `task`
- phase: `n/a`
- required_checks: `build,semgrep,rollout-governance`

## Validation

- `scripts/tests/create_pr_workflow_test.rb`

## Affected Files

```text
scripts/create-pr.sh
scripts/tests/create_pr_workflow_test.rb
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- CI `rollout-governance` currently fails due branch naming mismatch on this PR branch
- Code changes are scoped to `create-pr` fallback behavior and test coverage
