### PR TITLE
fix(cws-74): enforce create-pr drift guardrails

### DIFF
--- a/.agents/skills/repo-flow/scripts/infer-pr-metadata.sh
+++ b/.agents/skills/repo-flow/scripts/infer-pr-metadata.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 type="${1:-chore}"
 branch="$(git branch --show-current)"
 subject="${branch#codex/}"
+if [[ "$subject" =~ ^cws-([0-9]+)-(.*)$ ]]; then
+  issue_id="${BASH_REMATCH[1]}"
+  tail_subject="${BASH_REMATCH[2]}"
+  tail_subject="$(printf '%s' "$tail_subject" | tr '-' ' ')"
+  printf 'TITLE=%s(cws-%s): %s\n' "$type" "$issue_id" "$tail_subject"
+  exit 0
+fi
+
 subject="${subject#"${type}"-}"
 subject="$(printf '%s' "$subject" | tr '-' ' ')"
 

--- a/docs/agent-context.md
+++ b/docs/agent-context.md
@@ -8,9 +8,9 @@ This file is a bounded cache for agent continuity.
 
 ## Last Synced From Linear
 
-- Synced at: `2026-03-17 03:01:10 EDT`
+- Synced at: `2026-03-18 12:46:15 EDT`
 - Synced by: `Codex`
-- Scope: `CWS-64 merge + CWS-65 PR recovery (malformed branch superseded by compliant replacement PR)`
+- Scope: `Post-CWS-45/CWS-65 completion sync + NEXT queue refresh + new INFRA intake (CWS-66/CWS-69)`
 - Linear anchors:
   - `Program Index — Backlog Governance`
   - `Backlog Remediation Matrix — Master v2`
@@ -20,25 +20,26 @@ This file is a bounded cache for agent continuity.
 
 ## Stale After
 
-- `2026-03-18 03:01:10 EDT`
+- `2026-03-19 12:46:15 EDT`
 - Rule: if current time is later than this timestamp, run a full Linear re-sync before execution.
 
 ## Active Phase
 
-- `Implementation kickoff active — NEXT-5 queue sequenced and cycle-linked`
+- `Implementation kickoff active — NEXT queue sequenced, with new INFRA hardening intake pending placement`
 
 ## Top Priorities (max 5)
 
 1. Execute NEXT-10 sequence in dependency order:
-   `CWS-45 -> CWS-10 -> CWS-20 -> CWS-22 -> CWS-34 -> CWS-53 -> CWS-17 -> CWS-15 -> CWS-11 -> CWS-54`.
+   `CWS-10 -> CWS-20 -> CWS-22 -> CWS-34 -> CWS-53 -> CWS-17 -> CWS-15 -> CWS-11 -> CWS-54`.
 2. Keep all active execution issues linked to cycle `7ef11bc3-f086-40a6-afd9-256b27df384d`.
 3. Enforce cycle-first intake: any issue pulled from Linear for execution must be cycle-linked before queueing.
-4. Normalize PR flow: Graphite handles stack submit, `gh` enforces final PR title/body and draft readiness state.
-5. Complete `CWS-65` via compliant replacement PR (`#36`), then update Linear issue state and PR linkage.
+4. Place new INFRA hardening intake (`CWS-66` parent, `CWS-69` child) into the active dependency queue before execution.
+5. Normalize PR flow: Graphite handles stack submit, `gh` enforces final PR title/body and draft readiness state.
 
 ## Open Decisions
 
 - [ ] Confirm explicit owner go-ahead before moving from governance to implementation.
+- [ ] Decide whether `CWS-66`/`CWS-69` preempt any remaining NEXT-10 order.
 - [ ] Decide whether to enforce dependency linting via scripted audit in CI.
 - [ ] Decide when to split canonical mirror docs into section documents (if maintainability degrades).
 
@@ -53,21 +54,22 @@ This file is a bounded cache for agent continuity.
 
 ## Next 10 Actions
 
-- [ ] Start `CWS-45` (NEXT-10 #1) and move to `In Progress` at pickup.
-- [ ] After `CWS-45` merge, start `CWS-10` (NEXT-10 #2).
+- [ ] Start `CWS-10` (NEXT-10 #2) and move to `In Progress` at pickup.
 - [ ] After `CWS-10` merge, start `CWS-20` (NEXT-10 #3).
 - [ ] After `CWS-20` merge, start `CWS-22` (NEXT-10 #4).
 - [ ] After `CWS-22` merge, start `CWS-34` (NEXT-10 #5).
 - [ ] After `CWS-10` merge, schedule `CWS-53` (NEXT-10 #6).
 - [ ] Start dispatch chain: `CWS-17` (NEXT-10 #7) -> `CWS-15` (NEXT-10 #8) -> `CWS-11` (NEXT-10 #9).
 - [ ] After `CWS-34` merge, start `CWS-54` (NEXT-10 #10).
+- [ ] Add `CWS-66` and `CWS-69` to cycle `7ef11bc3-f086-40a6-afd9-256b27df384d` before they enter active execution.
+- [ ] Resolve queue placement for `CWS-66`/`CWS-69` against remaining NEXT-10 dependencies.
 - [ ] Keep cycle linkage intact and PR links attached before marking each issue `Done`.
-- [ ] Merge PR `#36` (`fix(cws-65): continue create-pr flow when gt restack fails`) after required checks are green.
-- [ ] Move `CWS-65` to `Done` and attach replacement PR link; ensure superseded PR `#35` remains closed with rationale.
 - [ ] Re-sync this ledger after each NEXT-10 completion and every follow-up remediation ticket.
 
 ## Recent Completions
 
+- [x] `CWS-65` is `Done` in Linear with merged replacement PR `#36` and superseded PR `#35` closed.
+- [x] `CWS-45` is `Done` in Linear after merge of PR `#32`.
 - [x] `CWS-64` executed in dedicated PR `#34` with normalized title/body; branch updated to latest `main`, checks passed, and PR merged.
 - [x] Malformed-branch draft PR `#35` superseded: replacement compliant branch `codex/cws-65-create-pr-gt-restack-fallback` created and published as PR `#36`.
 - [x] Superseded PR `#35` closed with replacement note to preserve auditability and unblock rollout-governance gate compliance.

--- a/docs/tasks/CWS-74.md
+++ b/docs/tasks/CWS-74.md
@@ -1,0 +1,34 @@
+# CWS-74 Task File
+
+## Source
+
+- Linear issue: `CWS-74`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-74/dev-enforce-task-file-agent-context-freshness-and-cws-title>
+- Generated: `2026-03-18`
+- Status: `In Review`
+
+## Objective
+
+Enforce task-file presence, agent-context freshness, and issue-token traceability in `create-pr`.
+
+## Scope Snapshot
+
+- In scope: hard gates in `scripts/create-pr.sh` and matching tests.
+- Out of scope: phase-branch migration.
+
+## Deterministic Acceptance Criteria
+
+1. Task branches fail PR creation when required `docs/tasks/CWS-<id>.md` is missing.
+2. Stale `docs/agent-context.md` fails PR creation.
+3. Inferred title must include matching issue token.
+
+## Validation Commands
+
+- `ruby scripts/tests/create_pr_workflow_test.rb`
+- `make qa-local`
+
+## Completion Evidence
+
+- Open PR: <https://github.com/shabib87/shabib87.github.io/pull/37>
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[INFRA] Repo Process & Tooling`

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -76,6 +76,63 @@ phase="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $4}')"
 phase_branch_pattern="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $5}')"
 required_checks="$(printf '%s' "$plan_info" | awk -F '\t' 'NR==1 {print $6}')"
 
+if ! ruby - "$repo_root/docs/agent-context.md" <<'RUBY'
+require "time"
+
+path = ARGV.fetch(0)
+unless File.file?(path)
+  warn "error: missing docs/agent-context.md"
+  exit 1
+end
+
+content = File.read(path)
+stale_section = content.match(/^## Stale After\s*$\n+((?:- .*\n)+)/m)
+if stale_section.nil?
+  warn "error: docs/agent-context.md is missing a parseable 'Stale After' section"
+  exit 1
+end
+
+ts_line = stale_section[1].lines.find { |line| line.match?(/^\s*-\s*`[^`]+`\s*$/) }
+if ts_line.nil?
+  warn "error: docs/agent-context.md is missing stale timestamp in 'Stale After' section"
+  exit 1
+end
+
+ts = ts_line[/`([^`]+)`/, 1]
+begin
+  stale_at = Time.parse(ts)
+rescue ArgumentError
+  warn "error: could not parse stale timestamp #{ts.inspect} in docs/agent-context.md"
+  exit 1
+end
+
+if Time.now > stale_at
+  warn "error: docs/agent-context.md is stale (stale_after=#{stale_at.strftime("%Y-%m-%d %H:%M:%S %Z")})"
+  exit 1
+end
+RUBY
+then
+  exit 1
+fi
+
+issue_id=""
+linear_issue_link=""
+if [[ "$branch_mode" == "task" ]]; then
+  if [[ "$branch" =~ ^codex/cws-([0-9]+)-[a-z0-9-]+$ ]]; then
+    issue_id="CWS-${BASH_REMATCH[1]}"
+    linear_issue_link="https://linear.app/codewithshabib/issue/${issue_id}"
+  else
+    echo "error: unable to derive issue id from task branch: $branch" >&2
+    exit 1
+  fi
+
+  task_file="$repo_root/docs/tasks/${issue_id}.md"
+  if [[ ! -f "$task_file" ]]; then
+    echo "error: missing required task file: docs/tasks/${issue_id}.md" >&2
+    exit 1
+  fi
+fi
+
 if [[ "$branch_mode" == "phase" && "$phase" -gt 1 ]]; then
   pr_index="$(gh pr list --state all --base "$base_branch" --limit 200 --json number,state,mergedAt,headRefName)"
 
@@ -113,6 +170,13 @@ fi
 
 title_line="$("$repo_root/.agents/skills/repo-flow/scripts/infer-pr-metadata.sh" "$type")"
 title="${title_line#TITLE=}"
+if [[ -n "$issue_id" ]]; then
+  if [[ "$title" != *"${issue_id}"* && "$title" != *"${issue_id,,}"* ]]; then
+    echo "error: inferred PR title must include ${issue_id} for traceability" >&2
+    echo "error: current inferred title: $title" >&2
+    exit 1
+  fi
+fi
 
 affected_files="$(git diff --name-only "$base_branch"...HEAD | awk 'NF' || true)"
 if [[ -z "$affected_files" ]]; then
@@ -155,6 +219,10 @@ cat > "$body_file" <<EOF
 ## Why
 
 - Standardize the change behind the repo's branch and PR workflow.
+
+## Linear Traceability
+
+- Issue: ${linear_issue_link:-"(phase branch / no direct CWS issue id)"}
 
 ## Rollout Metadata
 

--- a/scripts/tests/create_pr_workflow_test.rb
+++ b/scripts/tests/create_pr_workflow_test.rb
@@ -44,4 +44,22 @@ class CreatePrWorkflowTest < Minitest::Test
     assert_match(/if ! gt restack >>"\$gt_log_file" 2>&1; then/, script_body)
     assert_match(/cat "\$gt_log_file" >&2/, script_body)
   end
+
+  def test_hard_fails_when_agent_context_is_missing_or_stale
+    assert_match(/missing docs\/agent-context\.md/, script_body)
+    assert_match(/docs\/agent-context\.md is stale/, script_body)
+  end
+
+  def test_hard_fails_when_task_file_missing_for_task_branch
+    assert_match(/missing required task file: docs\/tasks\/\$\{issue_id\}\.md/, script_body)
+  end
+
+  def test_hard_fails_when_inferred_title_missing_issue_id
+    assert_match(/inferred PR title must include \$\{issue_id\} for traceability/, script_body)
+  end
+
+  def test_pr_body_includes_linear_traceability_link
+    assert_match(/## Linear Traceability/, script_body)
+    assert_match(/linear_issue_link/, script_body)
+  end
 end


### PR DESCRIPTION
## Summary

- Enforce hard drift guardrails in `scripts/create-pr.sh`.
- Require task file for task branches: `docs/tasks/CWS-<id>.md`.
- Require fresh `docs/agent-context.md` (stale check).
- Require inferred PR title to include matching issue token.
- Include Linear issue link section in generated PR body.
- Add current branch task brief: `docs/tasks/CWS-74.md`.
- Extend `scripts/tests/create_pr_workflow_test.rb` for new failure paths.

## Why

- Prevent silent workflow drift and guarantee task and PR traceability at PR creation time.

## Linear Traceability

- Parent: [CWS-73](https://linear.app/codewithshabib/issue/CWS-73/dev-remediate-docstasks-and-agent-context-drift-with-hard-create-pr)
- This PR: [CWS-74](https://linear.app/codewithshabib/issue/CWS-74/dev-enforce-task-file-agent-context-freshness-and-cws-title)

## Validation

- `ruby scripts/tests/create_pr_workflow_test.rb`
- `make qa-local`

## Self-review Notes

- `codex/phase-*` behavior is intentionally unchanged.
