### PR TITLE
docs(cws-75): align AGENTS and PR template traceability rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,34 @@
+## Branch And Title Convention
+
+- Branch: `codex/cws-<id>-<slug>` (task) or `codex/phase-<n>-<slug>` (rollout)
+- Task-branch PR title must include matching issue token (`CWS-<id>` or `cws-<id>`)
+- Include a direct Linear issue link in the PR body
+- For non-interactive stack submit (`gt submit --no-interactive`), replace this template body with a concrete summary before PR ready.
+
+## Traceability Checklist
+
+- [ ] Branch name matches approved pattern
+- [ ] PR title contains matching issue token (`CWS-<id>` or `cws-<id>`) (task branches)
+- [ ] `docs/tasks/CWS-<id>.md` exists and is committed (task branches)
+- [ ] `docs/agent-context.md` is fresh (not stale)
+- [ ] Linear issue link is present in this PR
+
 ## Summary
 
--
+- Describe what changed in one to three bullets.
 
 ## Why
 
--
+- Describe the user or workflow impact and why this change is needed.
+
+## Linear Traceability
+
+- Parent issue: `<link>`
+- This issue: `<link>`
 
 ## Validation
 
-- `make check`
+- `make qa-local`
 
 ## Affected Files
 
@@ -24,4 +44,5 @@
 
 ## Self-review Notes
 
--
+- Risk assessment:
+- Backward compatibility notes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,12 @@
 - Use Graphite CLI (`gt`) for stack lifecycle operations: `gt create`, `gt modify`, `gt restack`, `gt sync`, and `gt submit --no-interactive`.
 - Use GitHub CLI (`gh`) for GitHub object operations after submission: inspecting checks, viewing diffs, reading review state, commenting, and labeling.
 - Keep branch/stack state authoritative in `gt`; use `gh` as the GitHub surface inspection and operations layer.
+- If using `gt submit --no-interactive` for a stack, normalize each stack PR body with `gh pr edit --body-file <path>` before marking that PR ready.
 - For stacked PR work, avoid mixing direct `git push`/`git commit` with Graphite stack steps unless explicitly required for recovery.
 - Preflight branch naming before PR creation/submission. Accepted rollout patterns are `^codex/cws-\d+-[a-z0-9-]+$` and `^codex/phase-(\d+)-[a-z0-9-]+$`.
+- For task branches (`codex/cws-<id>-...`), `docs/tasks/CWS-<id>.md` must exist before PR creation.
+- `docs/agent-context.md` must be fresh (not past `Stale After`) before PR creation.
+- For task branches, PR titles must include the matching issue token for traceability (`CWS-<id>` or `cws-<id>`).
 - For PR metadata updates, do not pass multiline markdown directly in shell flags. Use `gh pr create/edit --body-file <path>` to avoid shell substitution and corrupted PR bodies.
 - If a PR head branch violates rollout naming policy, create a compliant replacement branch/PR and close the superseded PR with a replacement note.
 - If `gh` is authenticated but SSH push fails (`Permission denied (publickey)`), recovery can use `gh api repos/<owner>/<repo>/git/refs` to create the remote branch ref to the intended commit.

--- a/docs/tasks/CWS-75.md
+++ b/docs/tasks/CWS-75.md
@@ -1,0 +1,33 @@
+# CWS-75 Task File
+
+## Source
+
+- Linear issue: `CWS-75`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-75/dev-align-agents-and-pr-template-with-branch-and-cws-title>
+- Generated: `2026-03-18`
+- Status: `In Review`
+
+## Objective
+
+Align `AGENTS.md` and PR template policy with create-pr traceability enforcement.
+
+## Scope Snapshot
+
+- In scope: policy language and PR template guidance/checklist alignment.
+- Out of scope: behavioral changes outside documented workflow contracts.
+
+## Deterministic Acceptance Criteria
+
+1. `AGENTS.md` reflects task-file, fresh-context, and title-token requirements.
+2. PR template reflects traceability and non-interactive normalization guidance.
+3. Wording remains consistent with enforced create-pr behavior.
+
+## Validation Commands
+
+- `make qa-local`
+
+## Completion Evidence
+
+- Open PR: <https://github.com/shabib87/shabib87.github.io/pull/38>
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[INFRA] Repo Process & Tooling`


### PR DESCRIPTION
## Summary

- Align execution policy in `AGENTS.md` with enforced create-pr guardrails.
- Improve `.github/pull_request_template.md` so non-interactive submit does not leave low-signal placeholders.
- Add explicit guidance to normalize stack PR bodies after `gt submit --no-interactive`.
- Clarify title token rule as case-insensitive (`CWS-<id>` or `cws-<id>`).
- Add current branch task brief: `docs/tasks/CWS-75.md`.

## Why

- Keep policy and PR UX consistent with enforcement and avoid placeholder-style PR descriptions.

## Linear Traceability

- Parent: [CWS-73](https://linear.app/codewithshabib/issue/CWS-73/dev-remediate-docstasks-and-agent-context-drift-with-hard-create-pr)
- This PR: [CWS-75](https://linear.app/codewithshabib/issue/CWS-75/dev-align-agents-and-pr-template-with-branch-and-cws-title)

## Validation

- `make qa-local`

## Self-review Notes

- This branch defines durable behavior for non-interactive stack submission hygiene.
