### PR TITLE
docs(cws-76): backfill completed task files and refresh context ledger

### DIFF
--- a/docs/agent-context.md
+++ b/docs/agent-context.md
@@ -8,9 +8,9 @@ This file is a bounded cache for agent continuity.
 
 ## Last Synced From Linear
 
-- Synced at: `2026-03-18 12:46:15 EDT`
+- Synced at: `2026-03-18 13:11:51 EDT`
 - Synced by: `Codex`
-- Scope: `Post-CWS-45/CWS-65 completion sync + NEXT queue refresh + new INFRA intake (CWS-66/CWS-69)`
+- Scope: `Drift remediation kickoff (CWS-73 parent + CWS-74/75/76 sub-issues), task-file backfill, and create-pr enforcement rollout`
 - Linear anchors:
   - `Program Index — Backlog Governance`
   - `Backlog Remediation Matrix — Master v2`
@@ -20,7 +20,7 @@ This file is a bounded cache for agent continuity.
 
 ## Stale After
 
-- `2026-03-19 12:46:15 EDT`
+- `2026-03-19 13:11:51 EDT`
 - Rule: if current time is later than this timestamp, run a full Linear re-sync before execution.
 
 ## Active Phase
@@ -29,16 +29,18 @@ This file is a bounded cache for agent continuity.
 
 ## Top Priorities (max 5)
 
-1. Execute NEXT-10 sequence in dependency order:
+1. Execute drift remediation stack in dependency order:
+   `CWS-74 -> CWS-75 -> CWS-76` under parent `CWS-73`.
+2. Execute NEXT-10 sequence in dependency order:
    `CWS-10 -> CWS-20 -> CWS-22 -> CWS-34 -> CWS-53 -> CWS-17 -> CWS-15 -> CWS-11 -> CWS-54`.
-2. Keep all active execution issues linked to cycle `7ef11bc3-f086-40a6-afd9-256b27df384d`.
-3. Enforce cycle-first intake: any issue pulled from Linear for execution must be cycle-linked before queueing.
-4. Place new INFRA hardening intake (`CWS-66` parent, `CWS-69` child) into the active dependency queue before execution.
+3. Keep all active execution issues linked to cycle `7ef11bc3-f086-40a6-afd9-256b27df384d`.
+4. Enforce cycle-first intake: any issue pulled from Linear for execution must be cycle-linked before queueing.
 5. Normalize PR flow: Graphite handles stack submit, `gh` enforces final PR title/body and draft readiness state.
 
 ## Open Decisions
 
 - [ ] Confirm explicit owner go-ahead before moving from governance to implementation.
+- [ ] Decide when to migrate away from `codex/phase-*` branch mode in a separate dedicated task.
 - [ ] Decide whether `CWS-66`/`CWS-69` preempt any remaining NEXT-10 order.
 - [ ] Decide whether to enforce dependency linting via scripted audit in CI.
 - [ ] Decide when to split canonical mirror docs into section documents (if maintainability degrades).
@@ -54,6 +56,7 @@ This file is a bounded cache for agent continuity.
 
 ## Next 10 Actions
 
+- [ ] Merge remediation stack PRs `#37` -> `#38` -> `#39`, then move `CWS-74`, `CWS-75`, `CWS-76`, and parent `CWS-73` to `Done`.
 - [ ] Start `CWS-10` (NEXT-10 #2) and move to `In Progress` at pickup.
 - [ ] After `CWS-10` merge, start `CWS-20` (NEXT-10 #3).
 - [ ] After `CWS-20` merge, start `CWS-22` (NEXT-10 #4).
@@ -68,6 +71,8 @@ This file is a bounded cache for agent continuity.
 
 ## Recent Completions
 
+- [x] Created parent remediation issue `CWS-73` and cycle-linked sub-issues `CWS-74`, `CWS-75`, and `CWS-76`.
+- [x] Backfilled missing task snapshots: `docs/tasks/CWS-16.md`, `docs/tasks/CWS-45.md`, `docs/tasks/CWS-50.md`, `docs/tasks/CWS-64.md`, and `docs/tasks/CWS-65.md`.
 - [x] `CWS-65` is `Done` in Linear with merged replacement PR `#36` and superseded PR `#35` closed.
 - [x] `CWS-45` is `Done` in Linear after merge of PR `#32`.
 - [x] `CWS-64` executed in dedicated PR `#34` with normalized title/body; branch updated to latest `main`, checks passed, and PR merged.

--- a/docs/tasks/CWS-16.md
+++ b/docs/tasks/CWS-16.md
@@ -1,0 +1,36 @@
+# CWS-16 Task File (Backfilled)
+
+## Source
+
+- Linear issue: `CWS-16`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-16/dev-migrate-branch-naming-to-linear-first-convention>
+- Backfilled: `2026-03-18`
+- Status: `Done`
+
+## Objective
+
+Resolve branch-policy conflicts so normal execution uses `codex/cws-<id>-<slug>` while rollout governance keeps `codex/phase-<n>-<slug>` support.
+
+## Scope Snapshot
+
+- In scope: dual branch-pattern support across scripts, tests, and docs.
+- Out of scope: rollout manifest/evidence model redesign and policy bypass paths.
+
+## Deterministic Acceptance Criteria (Snapshot)
+
+1. Normal task branch standard is `codex/cws-<id>-<slug>`.
+2. Rollout validation accepts both compliant task and phase branch modes.
+3. `create-pr` and `finalize-merge` do not fail solely because branch is `codex/cws-*`.
+
+## Validation Commands (From Linear)
+
+- `bash scripts/run-rollout-governance-tests.sh`
+- `make codex-check`
+- `make qa-local`
+
+## Completion Evidence
+
+- Completed at: `2026-03-17T05:24:08.717Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/30>
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[INFRA] Repo Process & Tooling`

--- a/docs/tasks/CWS-45.md
+++ b/docs/tasks/CWS-45.md
@@ -1,0 +1,34 @@
+# CWS-45 Task File (Backfilled)
+
+## Source
+
+- Linear issue: `CWS-45`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-45/dev-create-docssopmd-commit-sop-v2-to-repo>
+- Backfilled: `2026-03-18`
+- Status: `Done`
+
+## Objective
+
+Create canonical `docs/sop.md` in the repo from approved SOP source.
+
+## Scope Snapshot
+
+- In scope: commit SOP mirror content and ensure lint/QA compliance.
+- Out of scope: policy rewrites beyond canonical synchronization.
+
+## Deterministic Acceptance Criteria (Snapshot)
+
+1. `docs/sop.md` contains expected SOP identity markers.
+2. Validation commands pass and PR merges to `main`.
+
+## Validation Commands (From Linear)
+
+- `rg -n "Codex Agent Orchestration SOP|Evidence standard" docs/sop.md`
+- `make qa-local`
+
+## Completion Evidence
+
+- Completed at: `2026-03-17T06:20:06.237Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/32>
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[INFRA] Repo Process & Tooling`

--- a/docs/tasks/CWS-50.md
+++ b/docs/tasks/CWS-50.md
@@ -1,0 +1,35 @@
+# CWS-50 Task File (Backfilled)
+
+## Source
+
+- Linear issue: `CWS-50`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-50/dev-create-structured-linear-intake-templates>
+- Backfilled: `2026-03-18`
+- Status: `Done`
+
+## Objective
+
+Create structured Linear intake templates aligned to execution-brief requirements.
+
+## Scope Snapshot
+
+- In scope: `dev`, `editorial-new`, and `editorial-update` templates under `.codex/docs/templates/`.
+- Out of scope: automatic template injection into Linear.
+
+## Deterministic Acceptance Criteria (Snapshot)
+
+1. Required templates exist in `.codex/docs/templates/`.
+2. Templates include Objective, Scope In, Scope Out, Validation Commands, DoR, and DoD sections.
+3. QA checks pass.
+
+## Validation Commands (From Linear)
+
+- `rg -n "Objective|Scope In|Scope Out|Validation Commands|DoR|DoD" .codex/docs/templates/*.md`
+- `make qa-local`
+
+## Completion Evidence
+
+- Completed at: `2026-03-17T05:35:42.732Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/31>
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[ORCHESTRATION] Agentic Workflow Design`

--- a/docs/tasks/CWS-64.md
+++ b/docs/tasks/CWS-64.md
@@ -1,0 +1,36 @@
+# CWS-64 Task File (Backfilled)
+
+## Source
+
+- Linear issue: `CWS-64`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-64/dev-cleanup-markdownlint-debt-in-docsmaster-planmd>
+- Backfilled: `2026-03-18`
+- Status: `Done`
+
+## Objective
+
+Remove temporary markdownlint suppression from `docs/master-plan.md` by fixing underlying violations.
+
+## Scope Snapshot
+
+- In scope: remove disable wrapper and fix markdownlint findings in `docs/master-plan.md`.
+- Out of scope: unrelated documentation or policy changes.
+
+## Deterministic Acceptance Criteria (Snapshot)
+
+1. No markdownlint disable wrapper remains in `docs/master-plan.md`.
+2. `markdownlint-cli2` check for file passes.
+3. `make qa-local` passes.
+
+## Validation Commands (From Linear)
+
+- `./.venv-tools/bin/pre-commit run markdownlint-cli2 --files docs/master-plan.md`
+- `make qa-local`
+
+## Completion Evidence
+
+- Completed at: `2026-03-17T06:50:34.748Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/34>
+- Related PR (superseded path): <https://github.com/shabib87/shabib87.github.io/pull/33>
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[INFRA] Repo Process & Tooling`

--- a/docs/tasks/CWS-65.md
+++ b/docs/tasks/CWS-65.md
@@ -1,0 +1,37 @@
+# CWS-65 Task File (Backfilled)
+
+## Source
+
+- Linear issue: `CWS-65`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-65/dev-ensure-create-pr-falls-back-to-gh-when-gt-restack-fails>
+- Backfilled: `2026-03-18`
+- Status: `Done`
+
+## Objective
+
+Ensure `scripts/create-pr.sh` falls back to `gh` flow when `gt restack` fails.
+
+## Scope Snapshot
+
+- In scope: fallback handling in `scripts/create-pr.sh` and corresponding tests.
+- Out of scope: branch-policy or unrelated PR metadata behavior changes.
+
+## Deterministic Acceptance Criteria (Snapshot)
+
+1. Script does not hard-fail on `gt restack` failure in restack-required path.
+2. Warning is emitted and fallback path remains reachable.
+3. Tests cover fallback behavior.
+4. `make qa-local` passes.
+
+## Validation Commands (From Linear)
+
+- `ruby scripts/tests/create_pr_workflow_test.rb`
+- `make qa-local`
+
+## Completion Evidence
+
+- Completed at: `2026-03-17T07:17:32.398Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/36>
+- Superseded PR (closed): <https://github.com/shabib87/shabib87.github.io/pull/35>
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[INFRA] Repo Process & Tooling`

--- a/docs/tasks/CWS-76.md
+++ b/docs/tasks/CWS-76.md
@@ -1,0 +1,33 @@
+# CWS-76 Task File
+
+## Source
+
+- Linear issue: `CWS-76`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-76/dev-backfill-completed-docstasks-files-and-refresh-agent-context>
+- Generated: `2026-03-18`
+- Status: `In Review`
+
+## Objective
+
+Backfill completed `docs/tasks` artifacts and refresh `docs/agent-context.md` baseline.
+
+## Scope Snapshot
+
+- In scope: add backfilled task snapshots for completed issues after CWS-41 and refresh context ledger timestamps/actions.
+- Out of scope: rollout phase model migration and unrelated workflow refactors.
+
+## Deterministic Acceptance Criteria
+
+1. Backfilled files exist for `CWS-16`, `CWS-45`, `CWS-50`, `CWS-64`, and `CWS-65`.
+2. `docs/agent-context.md` reflects remediation status and fresh sync window.
+3. Artifacts are committed and linked in PR.
+
+## Validation Commands
+
+- `make qa-local`
+
+## Completion Evidence
+
+- Open PR: <https://github.com/shabib87/shabib87.github.io/pull/39>
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[INFRA] Repo Process & Tooling`


### PR DESCRIPTION
## Summary

- Backfill missing historical task snapshots:
  - `docs/tasks/CWS-16.md`
  - `docs/tasks/CWS-45.md`
  - `docs/tasks/CWS-50.md`
  - `docs/tasks/CWS-64.md`
  - `docs/tasks/CWS-65.md`
- Add current branch task brief: `docs/tasks/CWS-76.md`.
- Correct `CWS-50` snapshot criteria wording to match actual template sections.
- Refresh `docs/agent-context.md` sync and stale timestamps.
- Remove re-queued remediation execution steps from `Next 10 Actions`; track merge-closeout instead.

## Why

- Restore auditability for completed work and re-establish deterministic task-file history.

## Linear Traceability

- Parent: [CWS-73](https://linear.app/codewithshabib/issue/CWS-73/dev-remediate-docstasks-and-agent-context-drift-with-hard-create-pr)
- This PR: [CWS-76](https://linear.app/codewithshabib/issue/CWS-76/dev-backfill-completed-docstasks-files-and-refresh-agent-context)

## Validation

- `make qa-local`

## Self-review Notes

- Backfills use structured snapshots from final Linear issue state and merged PR evidence.
