### PR TITLE
fix(cws-77): make finalize-merge stack-friendly and codify lifecycle closeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,18 @@
 - If a PR head branch violates rollout naming policy, create a compliant replacement branch/PR and close the superseded PR with a replacement note.
 - If `gh` is authenticated but SSH push fails (`Permission denied (publickey)`), recovery can use `gh api repos/<owner>/<repo>/git/refs` to create the remote branch ref to the intended commit.
 
+### Execution Lifecycle Policy
+
+- Start-of-work gate:
+  - create or confirm the target Linear issue before implementation begins
+  - for task branches (`codex/cws-<id>-...`), create `docs/tasks/CWS-<id>.md` before `make create-pr`
+  - refresh `docs/agent-context.md` before PR submission when stale
+- Review-closeout gate:
+  - reply to every open PR review thread with explicit disposition and rationale (`accepted`, `partial`, or `declined`)
+  - run `make qa-local` on the final reviewed branch tip before merge
+  - update the task file status/evidence and refresh `docs/agent-context.md` before final integration
+  - for stacks, finalize in downstack order; stack membership may target `main` or another rollout branch
+
 ### Codex Instruction Hygiene
 
 - `AGENTS.md` remains the execution policy for this repository. If any other document conflicts with `AGENTS.md`, follow `AGENTS.md` for execution and open a follow-up issue to reconcile docs.

--- a/docs/agent-context.md
+++ b/docs/agent-context.md
@@ -8,9 +8,9 @@ This file is a bounded cache for agent continuity.
 
 ## Last Synced From Linear
 
-- Synced at: `2026-03-18 13:11:51 EDT`
+- Synced at: `2026-03-18 13:59:31 EDT`
 - Synced by: `Codex`
-- Scope: `Drift remediation kickoff (CWS-73 parent + CWS-74/75/76 sub-issues), task-file backfill, and create-pr enforcement rollout`
+- Scope: `Repo-local drift-remediation closeout hardening (no new Linear pull): stack-friendly finalize-merge behavior plus start/closeout lifecycle policy`
 - Linear anchors:
   - `Program Index — Backlog Governance`
   - `Backlog Remediation Matrix — Master v2`
@@ -20,7 +20,7 @@ This file is a bounded cache for agent continuity.
 
 ## Stale After
 
-- `2026-03-19 13:11:51 EDT`
+- `2026-03-19 13:59:31 EDT`
 - Rule: if current time is later than this timestamp, run a full Linear re-sync before execution.
 
 ## Active Phase
@@ -29,8 +29,8 @@ This file is a bounded cache for agent continuity.
 
 ## Top Priorities (max 5)
 
-1. Execute drift remediation stack in dependency order:
-   `CWS-74 -> CWS-75 -> CWS-76` under parent `CWS-73`.
+1. Complete stack closeout hardening task `CWS-77` on top of remediation stack:
+   finalize-merge stack base handling + lifecycle policy codification.
 2. Execute NEXT-10 sequence in dependency order:
    `CWS-10 -> CWS-20 -> CWS-22 -> CWS-34 -> CWS-53 -> CWS-17 -> CWS-15 -> CWS-11 -> CWS-54`.
 3. Keep all active execution issues linked to cycle `7ef11bc3-f086-40a6-afd9-256b27df384d`.
@@ -56,6 +56,7 @@ This file is a bounded cache for agent continuity.
 
 ## Next 10 Actions
 
+- [ ] Merge closeout hardening PR for `CWS-77` after review, then move `CWS-77` to `Done`.
 - [ ] Merge remediation stack PRs `#37` -> `#38` -> `#39`, then move `CWS-74`, `CWS-75`, `CWS-76`, and parent `CWS-73` to `Done`.
 - [ ] Start `CWS-10` (NEXT-10 #2) and move to `In Progress` at pickup.
 - [ ] After `CWS-10` merge, start `CWS-20` (NEXT-10 #3).
@@ -103,8 +104,8 @@ This file is a bounded cache for agent continuity.
 
 ## Workflow Learnings (Last 5 Sessions)
 
+- [x] Stack merge finalization must accept rollout stack bases, not only `main`, to avoid blocking valid upstack PR integration.
 - [x] Fallback coverage across `gt submit` and `gt restack` materially reduced PR-creation failure impact.
 - [x] Rollout branch naming validation is a hard merge gate. Enforce regex preflight before PR creation/submission.
 - [x] `gh` PR body updates should always use `--body-file` to avoid shell backtick substitution in multiline markdown.
 - [x] Recovery playbook is validated: when a malformed branch blocks CI, create a compliant replacement PR and close the superseded PR with rationale.
-- [x] Recovery path is validated for auth mismatches: if `gh` API works but SSH push fails, create remote refs with `gh api` as a scoped fallback.

--- a/docs/tasks/CWS-77.md
+++ b/docs/tasks/CWS-77.md
@@ -1,0 +1,35 @@
+# CWS-77 Task File
+
+## Source
+
+- Linear issue: `CWS-77`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-77/dev-make-finalize-merge-stack-friendly-and-codify-startcloseout>
+- Generated: `2026-03-18`
+- Status: `In Progress`
+
+## Objective
+
+Make stack closeout merge flow Graphite-friendly by allowing rollout stack PR base branches in `scripts/finalize-merge.sh`.
+
+## Scope Snapshot
+
+- In scope: finalize-merge base validation update, merge-checklist output update, lifecycle policy documentation, and tests.
+- Out of scope: replacing merge execution with Graphite merge commands or changing rollout branch patterns.
+
+## Deterministic Acceptance Criteria
+
+1. `scripts/finalize-merge.sh` accepts PR bases that are either `main` or rollout stack branches.
+2. `scripts/tests/*` covers the new finalize-merge base behavior.
+3. `AGENTS.md` and `docs/agent-context.md` explicitly codify start-of-work and review-closeout expectations.
+
+## Validation Commands
+
+- `ruby scripts/tests/create_pr_workflow_test.rb`
+- `ruby scripts/tests/finalize_merge_workflow_test.rb`
+- `make qa-local`
+
+## Completion Evidence
+
+- Branch: `codex/cws-77-finalize-merge-stack-friendly`
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[INFRA] Repo Process & Tooling`

--- a/scripts/finalize-merge.sh
+++ b/scripts/finalize-merge.sh
@@ -73,7 +73,12 @@ required_checks = ARGV.fetch(4).split(",").map(&:strip).reject(&:empty?)
 
 errors = []
 errors << "PR is still a draft" if pr["isDraft"] == true
-errors << "PR base #{pr["baseRefName"].inspect} must be #{base_branch.inspect}" if pr["baseRefName"] != base_branch
+base_ref = pr["baseRefName"].to_s
+base_is_trunk = base_ref == base_branch
+base_is_stack_branch = task_branch_pattern.match?(base_ref) || phase_branch_pattern.match?(base_ref)
+unless base_is_trunk || base_is_stack_branch
+  errors << "PR base #{base_ref.inspect} must be #{base_branch.inspect} or a rollout stack branch"
+end
 
 head = pr["headRefName"].to_s
 branch_mode = nil
@@ -117,7 +122,7 @@ if errors.any?
   exit 1
 end
 
-puts [pr["url"], branch_mode, phase, head].join("\t")
+puts [pr["url"], branch_mode, phase, head, base_ref].join("\t")
 RUBY
 )"
 
@@ -125,6 +130,7 @@ pr_url="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $1}')"
 branch_mode="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $2}')"
 phase="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $3}')"
 head_branch="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $4}')"
+base_ref_name="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $5}')"
 
 if [[ "$branch_mode" == "phase" && "$phase" -gt 1 ]]; then
   pr_index="$(gh pr list --state all --base "$base_branch" --limit 200 --json number,state,mergedAt,headRefName)"
@@ -192,6 +198,7 @@ Self-review checklist for $pr_url
 - branch mode: $branch_mode
 - phase: ${phase:-n/a}
 - head branch: $head_branch
+- base branch: $base_ref_name
 - full local QA gate passed (\`make qa-local\`)
 - diff reviewed
 - no private drafts or secrets included

--- a/scripts/tests/finalize_merge_workflow_test.rb
+++ b/scripts/tests/finalize_merge_workflow_test.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "minitest/autorun"
+
+class FinalizeMergeWorkflowTest < Minitest::Test
+  SCRIPT_PATH = File.expand_path("../finalize-merge.sh", __dir__)
+
+  def script_body
+    @script_body ||= File.read(SCRIPT_PATH)
+  end
+
+  def test_allows_rollout_stack_base_branches
+    assert_match(/base_is_stack_branch = task_branch_pattern\.match\?\(base_ref\) \|\| phase_branch_pattern\.match\?\(base_ref\)/, script_body)
+    assert_includes(script_body, "or a rollout stack branch")
+  end
+
+  def test_still_merges_with_rebase_and_deletes_branch
+    assert_match(/gh pr merge "\$pr" --rebase --delete-branch/, script_body)
+  end
+
+  def test_self_review_checklist_prints_pr_base_branch
+    assert_match(/- base branch: \$base_ref_name/, script_body)
+  end
+end


### PR DESCRIPTION
## Summary

- Make `scripts/finalize-merge.sh` stack-friendly by allowing rollout stack branch bases in addition to trunk.
- Add finalize-merge workflow test coverage for stack-base behavior.
- Codify start-of-work and review-closeout lifecycle policy in `AGENTS.md`.
- Refresh `docs/agent-context.md` and add `docs/tasks/CWS-77.md` for traceability.

## Why

- The previous finalize flow could block valid upstack PR integration because it required PR base == `main`.
- Lifecycle drift was recurring around issue/task/context sync and review closeout steps.

## Linear Traceability

- Issue: https://linear.app/codewithshabib/issue/CWS-77/dev-make-finalize-merge-stack-friendly-and-codify-startcloseout
- Parent: https://linear.app/codewithshabib/issue/CWS-73/dev-remediate-docstasks-and-agent-context-drift-with-hard-create-pr

## Validation

- `ruby scripts/tests/finalize_merge_workflow_test.rb`
- `make qa-local`

## Self-review Notes

- Full local QA gate passed.
- Diff reviewed for stack merge compatibility and policy consistency.
