### PR TITLE
fix(cws-78): graphite merge flow clarity

### DIFF
--- a/.codex/prompts/repo-workflow.md
+++ b/.codex/prompts/repo-workflow.md
@@ -7,4 +7,5 @@ Use this repository's standard repo flow.
 - Do not commit until `make qa-local` passes.
 - Group related changes into clean Conventional Commits after the full local QA gate is green.
 - Re-run `make qa-local` on the committed tree before push and PR creation.
-- Use `make create-pr` and `make finalize-merge` instead of ad hoc PR and integration commands.
+- Use `make create-pr` for PR creation/submission.
+- Use `make finalize-merge` for single-PR integration and Graphite stack merge (`gt merge` or Graphite web) for stacked PR integration.

--- a/docs/agent-context.md
+++ b/docs/agent-context.md
@@ -8,9 +8,9 @@ This file is a bounded cache for agent continuity.
 
 ## Last Synced From Linear
 
-- Synced at: `2026-03-18 13:59:31 EDT`
+- Synced at: `2026-03-18 14:43:46 EDT`
 - Synced by: `Codex`
-- Scope: `Repo-local drift-remediation closeout hardening (no new Linear pull): stack-friendly finalize-merge behavior plus start/closeout lifecycle policy`
+- Scope: `Post-merge cleanup and CWS-78 kickoff: clarify Graphite stack merge versus gh single-PR finalize flow`
 - Linear anchors:
   - `Program Index — Backlog Governance`
   - `Backlog Remediation Matrix — Master v2`
@@ -20,7 +20,7 @@ This file is a bounded cache for agent continuity.
 
 ## Stale After
 
-- `2026-03-19 13:59:31 EDT`
+- `2026-03-19 14:43:46 EDT`
 - Rule: if current time is later than this timestamp, run a full Linear re-sync before execution.
 
 ## Active Phase
@@ -29,8 +29,8 @@ This file is a bounded cache for agent continuity.
 
 ## Top Priorities (max 5)
 
-1. Complete stack closeout hardening task `CWS-77` on top of remediation stack:
-   finalize-merge stack base handling + lifecycle policy codification.
+1. Complete merge-flow clarity task `CWS-78`:
+   explicit stack-vs-single merge guidance in finalize workflow, tests, and prompts.
 2. Execute NEXT-10 sequence in dependency order:
    `CWS-10 -> CWS-20 -> CWS-22 -> CWS-34 -> CWS-53 -> CWS-17 -> CWS-15 -> CWS-11 -> CWS-54`.
 3. Keep all active execution issues linked to cycle `7ef11bc3-f086-40a6-afd9-256b27df384d`.
@@ -56,8 +56,8 @@ This file is a bounded cache for agent continuity.
 
 ## Next 10 Actions
 
-- [ ] Merge closeout hardening PR for `CWS-77` after review, then move `CWS-77` to `Done`.
-- [ ] Merge remediation stack PRs `#37` -> `#38` -> `#39`, then move `CWS-74`, `CWS-75`, `CWS-76`, and parent `CWS-73` to `Done`.
+- [ ] Ship `CWS-78` PR: finalize-merge prompt clarity, stacked-merge guardrail note, and tests.
+- [ ] After `CWS-78` merge, move `CWS-78` to `Done` with PR linkage.
 - [ ] Start `CWS-10` (NEXT-10 #2) and move to `In Progress` at pickup.
 - [ ] After `CWS-10` merge, start `CWS-20` (NEXT-10 #3).
 - [ ] After `CWS-20` merge, start `CWS-22` (NEXT-10 #4).
@@ -72,6 +72,10 @@ This file is a bounded cache for agent continuity.
 
 ## Recent Completions
 
+- [x] Remediation stack merged end-to-end: `#37`, `#38`, `#39`, and `#40` landed on `main`.
+- [x] Stack merge observation confirmed: Graphite merge flow can appear delayed while rebases/checks execute; final merge completed without manual conflict intervention.
+- [x] Local Graphite/git cleanup completed post-merge (`gt sync --no-interactive --force`), merged branches pruned, local `main` fast-forwarded.
+- [x] Created new execution issue `CWS-78` (`In Progress`) and task file `docs/tasks/CWS-78.md` for merge-flow clarity hardening.
 - [x] Created parent remediation issue `CWS-73` and cycle-linked sub-issues `CWS-74`, `CWS-75`, and `CWS-76`.
 - [x] Backfilled missing task snapshots: `docs/tasks/CWS-16.md`, `docs/tasks/CWS-45.md`, `docs/tasks/CWS-50.md`, `docs/tasks/CWS-64.md`, and `docs/tasks/CWS-65.md`.
 - [x] `CWS-65` is `Done` in Linear with merged replacement PR `#36` and superseded PR `#35` closed.

--- a/docs/tasks/CWS-78.md
+++ b/docs/tasks/CWS-78.md
@@ -1,0 +1,33 @@
+# CWS-78 Task File
+
+## Source
+
+- Linear issue: `CWS-78`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-78/dev-clarify-graphite-vs-github-merge-paths-in-finalize-flow-and-harden>
+- Generated: `2026-03-18`
+- Status: `In Progress`
+
+## Objective
+
+Clarify stacked versus single-PR merge behavior so `scripts/finalize-merge.sh` is explicit about when Graphite stack merge should be used.
+
+## Scope Snapshot
+
+- In scope: finalize-merge messaging and prompt hardening, stacked-PR guardrail notes, tests, and workflow prompt alignment.
+- Out of scope: replacing merge execution with `gt merge` in this task.
+
+## Deterministic Acceptance Criteria
+
+1. `scripts/finalize-merge.sh` prompt references the PR base branch target and clearly identifies single-PR merge semantics.
+2. Stacked-base PRs print an explicit note directing full-stack merges to Graphite stack merge (`gt merge` or Graphite web).
+3. `scripts/tests/finalize_merge_workflow_test.rb` covers the new messaging/guardrails.
+
+## Validation Commands
+
+- `ruby scripts/tests/finalize_merge_workflow_test.rb`
+- `make qa-local`
+
+## Completion Evidence
+
+- Branch: `codex/cws-78-graphite-merge-flow-clarity`
+- Project: `[INFRA] Repo Process & Tooling`

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -171,7 +171,8 @@ fi
 title_line="$("$repo_root/.agents/skills/repo-flow/scripts/infer-pr-metadata.sh" "$type")"
 title="${title_line#TITLE=}"
 if [[ -n "$issue_id" ]]; then
-  if [[ "$title" != *"${issue_id}"* && "$title" != *"${issue_id,,}"* ]]; then
+  issue_id_lower="$(printf '%s' "$issue_id" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$title" != *"${issue_id}"* && "$title" != *"${issue_id_lower}"* ]]; then
     echo "error: inferred PR title must include ${issue_id} for traceability" >&2
     echo "error: current inferred title: $title" >&2
     exit 1

--- a/scripts/finalize-merge.sh
+++ b/scripts/finalize-merge.sh
@@ -131,6 +131,10 @@ branch_mode="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $2}')"
 phase="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $3}')"
 head_branch="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $4}')"
 base_ref_name="$(printf '%s' "$validation" | awk -F '\t' 'NR==1 {print $5}')"
+is_stack_base="false"
+if [[ "$base_ref_name" != "$base_branch" ]]; then
+  is_stack_base="true"
+fi
 
 if [[ "$branch_mode" == "phase" && "$phase" -gt 1 ]]; then
   pr_index="$(gh pr list --state all --base "$base_branch" --limit 200 --json number,state,mergedAt,headRefName)"
@@ -199,13 +203,21 @@ Self-review checklist for $pr_url
 - phase: ${phase:-n/a}
 - head branch: $head_branch
 - base branch: $base_ref_name
+- merge engine: gh (single PR rebase merge)
 - full local QA gate passed (\`make qa-local\`)
 - diff reviewed
 - no private drafts or secrets included
 - PR title/body look correct
 - changed files and URLs are expected
 EOF
-printf 'Integrate this PR to %s with rebase? [y/N] ' "$base_branch"
+if [[ "$is_stack_base" == "true" ]]; then
+  cat <<EOF
+stacked PR note:
+- this script merges only the current PR into its base branch ($base_ref_name).
+- to merge the full stack, use Graphite web "Merge stack" or run: gt merge
+EOF
+fi
+printf 'Integrate this PR into %s via GitHub rebase merge (single PR only)? [y/N] ' "$base_ref_name"
 read -r confirm
 if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
   echo "integration cancelled"

--- a/scripts/tests/finalize_merge_workflow_test.rb
+++ b/scripts/tests/finalize_merge_workflow_test.rb
@@ -22,4 +22,12 @@ class FinalizeMergeWorkflowTest < Minitest::Test
   def test_self_review_checklist_prints_pr_base_branch
     assert_match(/- base branch: \$base_ref_name/, script_body)
   end
+
+  def test_prompt_targets_pr_base_for_single_pr_merge
+    assert_match(/Integrate this PR into %s via GitHub rebase merge \(single PR only\)\? \[y\/N\]/, script_body)
+  end
+
+  def test_stack_note_points_to_graphite_stack_merge
+    assert_includes(script_body, "to merge the full stack, use Graphite web \"Merge stack\" or run: gt merge")
+  end
 end


### PR DESCRIPTION
## Summary

- fix(cws-78): graphite merge flow clarity

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Linear Traceability

- Issue: https://linear.app/codewithshabib/issue/CWS-78

## Rollout Metadata

- plan_id: `governance-v3`
- branch_mode: `task`
- phase: `n/a`
- required_checks: `build,semgrep,rollout-governance`

## Validation

- `make qa-local`

## Affected Files

```text
.codex/prompts/repo-workflow.md
docs/agent-context.md
docs/tasks/CWS-78.md
scripts/create-pr.sh
scripts/finalize-merge.sh
scripts/tests/finalize_merge_workflow_test.rb
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
