### PR TITLE
docs(cws-79): task context single writer

### DIFF
--- a/.agents/skills/repo-flow/SKILL.md
+++ b/.agents/skills/repo-flow/SKILL.md
@@ -18,6 +18,7 @@ Use this skill for repo mechanics.
 
 - clean branch creation
 - consistent PR title/body
+- deterministic task-context bootstrap from `docs/tasks/CWS-<id>.md`
 - local-first validation before PR
 - solo self-review rebase integration flow
 
@@ -36,3 +37,5 @@ Use this skill for repo mechanics.
 - Require valid `gh` authentication for PR and rebase integration commands.
 - Keep history linear and prefer rebase-only integration behavior.
 - Do not require external reviewer approval for this repo; require explicit self-review instead.
+- For task branches, require `docs/tasks/CWS-<id>.md` to exist, but do not treat local task-file `Status` text as merge-gating state.
+- Use Linear as the mutable execution-status source of truth; keep task files focused on execution brief and evidence pointers.

--- a/.agents/skills/repo-flow/SKILL.md
+++ b/.agents/skills/repo-flow/SKILL.md
@@ -36,7 +36,7 @@ Use this skill for repository workflow mechanics only.
 2. Read `references/context7-verification.md` only when command behavior depends on official docs.
 3. Use repository scripts and `make` targets instead of ad hoc git/gh sequences.
 4. Run `make qa-local` before commit, before PR creation, and again on the committed tree before push or rebase integration.
-5. For task branches, require `docs/tasks/CWS-<id>.md` to exist; treat local task-file status as informational only.
+5. For task branches, require `docs/tasks/CWS-<id>.md` to exist; do not maintain mutable status text in the task file.
 6. Keep Linear as mutable execution-status source of truth and keep PR traceability links current.
 
 ## Outputs
@@ -61,7 +61,7 @@ Use this skill for repository workflow mechanics only.
 - Require valid `gh` authentication for PR and rebase integration commands.
 - Keep history linear and prefer rebase-only integration behavior.
 - Do not require external reviewer approval for this repo; require explicit self-review instead.
-- For task branches, require `docs/tasks/CWS-<id>.md` to exist; do not treat local task-file `Status` text as merge-gating state.
+- For task branches, require `docs/tasks/CWS-<id>.md` to exist; do not maintain mutable status text in the task file.
 - Use Linear as the mutable execution-status source of truth; keep task files focused on execution brief and evidence pointers.
 
 ## Trigger Quality Check

--- a/.agents/skills/repo-flow/SKILL.md
+++ b/.agents/skills/repo-flow/SKILL.md
@@ -1,32 +1,56 @@
 ---
 name: repo-flow
-description: Standardize git, validation, PR, and rebase-only integration workflow for this repository. Use when starting new work, running repo checks, preparing a pull request, finalizing rebase integration, or aligning work with the repo's trunk-based development policy.
+description: Use this skill when the user asks to start, validate, package, or integrate repository changes in this repo using its scripted workflow (`make qa-local`, `make create-pr`, `make finalize-merge`) and policy gates (branch naming, task file presence, Linear traceability, rebase-only integration). Use it even when requested indirectly ("open a PR", "finish merge", "prep branch"). Do not use for editorial drafting or content-only edits that do not involve repo workflow mechanics, and do not use for generic git advice outside this repository.
 ---
 
 # Repo Flow
 
-Use this skill for repo mechanics.
+Use this skill for repository workflow mechanics only.
 
-## Workflow
+## Trigger Boundaries
+
+### Should Trigger
+
+- Start work on a new task branch.
+- Run repo checks and validate readiness for PR.
+- Create or normalize PR metadata using repo scripts.
+- Finalize integration with rebase-only workflow and check gates.
+- Resolve branch/PR workflow policy conflicts in this repository.
+
+### Should Not Trigger
+
+- Drafting or editing post content where repo flow is not the problem.
+- Fact checking or editorial QA requests.
+- Generic cross-repo git tutoring with no repository-specific workflow ask.
+
+## Inputs
+
+- Current branch and working tree state.
+- Target issue/branch context (for task branches, `CWS-<id>`).
+- Repository policy files and scripts:
+  `AGENTS.md`, `scripts/create-pr.sh`, `scripts/finalize-merge.sh`, and `make` targets.
+
+## Procedure
 
 1. Read `references/branch-pr-merge.md`.
-2. Read `references/context7-verification.md` when command behavior depends on official docs.
-3. Use the scripts in this skill and the repo root `scripts/` commands instead of ad hoc git/gh sequences.
-4. Require `make qa-local` before commit, before PR creation, and again on the committed tree before push or rebase integration.
+2. Read `references/context7-verification.md` only when command behavior depends on official docs.
+3. Use repository scripts and `make` targets instead of ad hoc git/gh sequences.
+4. Run `make qa-local` before commit, before PR creation, and again on the committed tree before push or rebase integration.
+5. For task branches, require `docs/tasks/CWS-<id>.md` to exist; treat local task-file status as informational only.
+6. Keep Linear as mutable execution-status source of truth and keep PR traceability links current.
 
-## Output Expectations
+## Outputs
 
-- clean branch creation
-- consistent PR title/body
-- deterministic task-context bootstrap from `docs/tasks/CWS-<id>.md`
-- local-first validation before PR
-- solo self-review rebase integration flow
+- Branch and PR actions consistent with repo policy.
+- Validation evidence from required local checks.
+- PR packaging with correct title/body/traceability fields.
+- Rebase-only integration flow with explicit self-review checkpoint.
 
 ## Done Criteria
 
-- the work is packaged in a PR with clean commits
-- local checks passed
-- the rebase-only integration path is explicit and safe for a solo maintainer
+- Work is packaged in a PR with clean commits.
+- Required local checks have passed.
+- Integration path is explicit, rebase-only, and policy-compliant.
 
 ## Rules
 
@@ -37,5 +61,12 @@ Use this skill for repo mechanics.
 - Require valid `gh` authentication for PR and rebase integration commands.
 - Keep history linear and prefer rebase-only integration behavior.
 - Do not require external reviewer approval for this repo; require explicit self-review instead.
-- For task branches, require `docs/tasks/CWS-<id>.md` to exist, but do not treat local task-file `Status` text as merge-gating state.
+- For task branches, require `docs/tasks/CWS-<id>.md` to exist; do not treat local task-file `Status` text as merge-gating state.
 - Use Linear as the mutable execution-status source of truth; keep task files focused on execution brief and evidence pointers.
+
+## Trigger Quality Check
+
+After updating this skill description, sanity-check with 6 to 10 prompts:
+
+- Should trigger: branch start, `make create-pr`, `make finalize-merge`, rollout gate failures.
+- Should not trigger: pure editorial drafting, pure fact-checking, generic git question without repo workflow context.

--- a/.agents/skills/repo-flow/references/branch-pr-merge.md
+++ b/.agents/skills/repo-flow/references/branch-pr-merge.md
@@ -14,7 +14,7 @@
 - keep the working tree clean before PR creation
 - use Conventional Commit style for the PR title
 - include summary, why, validation, affected files, affected URLs, and self-review notes
-- for task branches, require `docs/tasks/CWS-<id>.md` as local execution context; do not gate on local task-file status text
+- for task branches, require `docs/tasks/CWS-<id>.md` as local execution context; do not maintain mutable status text in the task file
 
 ## Integration
 
@@ -22,4 +22,4 @@
 - if CI has reported, require it to be green
 - integrate with rebase only for a linear history
 - delete the branch after integration
-- keep Linear issue and PR traceability links current; treat local task-file status as informational only
+- keep Linear issue and PR traceability links current; keep mutable status transitions in Linear only

--- a/.agents/skills/repo-flow/references/branch-pr-merge.md
+++ b/.agents/skills/repo-flow/references/branch-pr-merge.md
@@ -14,6 +14,7 @@
 - keep the working tree clean before PR creation
 - use Conventional Commit style for the PR title
 - include summary, why, validation, affected files, affected URLs, and self-review notes
+- for task branches, require `docs/tasks/CWS-<id>.md` as local execution context; do not gate on local task-file status text
 
 ## Integration
 
@@ -21,3 +22,4 @@
 - if CI has reported, require it to be green
 - integrate with rebase only for a linear history
 - delete the branch after integration
+- keep Linear issue and PR traceability links current; treat local task-file status as informational only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@
 - For stacked PR work, avoid mixing direct `git push`/`git commit` with Graphite stack steps unless explicitly required for recovery.
 - Preflight branch naming before PR creation/submission. Accepted rollout patterns are `^codex/cws-\d+-[a-z0-9-]+$` and `^codex/phase-(\d+)-[a-z0-9-]+$`.
 - For task branches (`codex/cws-<id>-...`), `docs/tasks/CWS-<id>.md` must exist before PR creation.
-- Treat `docs/tasks/CWS-<id>.md` as a context snapshot. Any local `Status` field is informational only; Linear is the mutable execution-status source of truth.
+- Treat `docs/tasks/CWS-<id>.md` as a context snapshot and avoid mutable status fields in the file. Linear is the mutable execution-status source of truth.
 - `docs/agent-context.md` must be fresh (not past `Stale After`) before PR creation.
 - For task branches, PR titles must include the matching issue token for traceability (`CWS-<id>` or `cws-<id>`).
 - For PR metadata updates, do not pass multiline markdown directly in shell flags. Use `gh pr create/edit --body-file <path>` to avoid shell substitution and corrupted PR bodies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@
 - For stacked PR work, avoid mixing direct `git push`/`git commit` with Graphite stack steps unless explicitly required for recovery.
 - Preflight branch naming before PR creation/submission. Accepted rollout patterns are `^codex/cws-\d+-[a-z0-9-]+$` and `^codex/phase-(\d+)-[a-z0-9-]+$`.
 - For task branches (`codex/cws-<id>-...`), `docs/tasks/CWS-<id>.md` must exist before PR creation.
+- Treat `docs/tasks/CWS-<id>.md` as a context snapshot. Any local `Status` field is informational only; Linear is the mutable execution-status source of truth.
 - `docs/agent-context.md` must be fresh (not past `Stale After`) before PR creation.
 - For task branches, PR titles must include the matching issue token for traceability (`CWS-<id>` or `cws-<id>`).
 - For PR metadata updates, do not pass multiline markdown directly in shell flags. Use `gh pr create/edit --body-file <path>` to avoid shell substitution and corrupted PR bodies.
@@ -78,7 +79,7 @@
 - Review-closeout gate:
   - reply to every open PR review thread with explicit disposition and rationale (`accepted`, `partial`, or `declined`)
   - run `make qa-local` on the final reviewed branch tip before merge
-  - update the task file status/evidence and refresh `docs/agent-context.md` before final integration
+  - ensure Linear issue and PR traceability/evidence links are current, and refresh `docs/agent-context.md` before final integration
   - for stacks, finalize in downstack order; stack membership may target `main` or another rollout branch
 
 ### Codex Instruction Hygiene

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -391,7 +391,7 @@ Where `NNN` is the Linear issue number (e.g., `docs/tasks/CWS-42.md`).
 
 - Linear is the mutable execution-status source of truth (`Backlog`/`Todo`/`In Progress`/`In Review`/`Done`).
 - `docs/tasks/CWS-NNN.md` is a local execution-context snapshot and evidence pointer.
-- If a task file includes a `Status` field, treat it as informational only. Do not use it as a merge gate.
+- Do not maintain mutable status fields in task files. Keep status transitions in Linear only.
 
 ### File structure
 

--- a/docs/master-plan.md
+++ b/docs/master-plan.md
@@ -387,6 +387,12 @@ Where `NNN` is the Linear issue number (e.g., `docs/tasks/CWS-42.md`).
 | Codex picks up task      | Agent reads from `docs/tasks/CWS-NNN.md`                          |
 | Task complete, PR merged | File persists as historical record                                |
 
+### Single-Writer Status Model
+
+- Linear is the mutable execution-status source of truth (`Backlog`/`Todo`/`In Progress`/`In Review`/`Done`).
+- `docs/tasks/CWS-NNN.md` is a local execution-context snapshot and evidence pointer.
+- If a task file includes a `Status` field, treat it as informational only. Do not use it as a merge gate.
+
 ### File structure
 
 ```markdown
@@ -408,6 +414,19 @@ Where `NNN` is the Linear issue number (e.g., `docs/tasks/CWS-42.md`).
 
 [Extracted from issue body]
 
+## Validation Commands
+
+[Deterministic validation command list]
+
+## Captured From Linear
+
+- Timestamp: YYYY-MM-DD HH:MM:SS TZ
+
+## Evidence (Optional)
+
+- PR: https://github.com/<owner>/<repo>/pull/<id>
+- Completed at: YYYY-MM-DDTHH:MM:SSZ
+
 ## Labels
 
 [Labels from Linear]
@@ -416,6 +435,8 @@ Where `NNN` is the Linear issue number (e.g., `docs/tasks/CWS-42.md`).
 
 [Sub-issues if any, with their CWS IDs]
 ```
+
+Canonical template: `docs/tasks/TEMPLATE.md`.
 
 ### Git tracking
 
@@ -1225,6 +1246,7 @@ _Last updated: YYYY-MM-DD by [agent-name] during CWS-NNN_
 - Updates are committed as part of the task branch — reviewed in the PR like any other change.
 - Shabib reviews the context file periodically and corrects any drift.
 - Add to `AGENTS.md`:
+
   ```text
   Before starting any task, read docs/agent-context.md for project context.
   After completing a task, update the relevant section if anything changed.

--- a/docs/tasks/CWS-74.md
+++ b/docs/tasks/CWS-74.md
@@ -5,7 +5,7 @@
 - Linear issue: `CWS-74`
 - Linear URL: <https://linear.app/codewithshabib/issue/CWS-74/dev-enforce-task-file-agent-context-freshness-and-cws-title>
 - Generated: `2026-03-18`
-- Status: `In Review`
+- Status: `Done`
 
 ## Objective
 
@@ -29,6 +29,7 @@ Enforce task-file presence, agent-context freshness, and issue-token traceabilit
 
 ## Completion Evidence
 
-- Open PR: <https://github.com/shabib87/shabib87.github.io/pull/37>
+- Completed at: `2026-03-18T18:15:39.028Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/37>
 - Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
 - Project: `[INFRA] Repo Process & Tooling`

--- a/docs/tasks/CWS-75.md
+++ b/docs/tasks/CWS-75.md
@@ -5,7 +5,7 @@
 - Linear issue: `CWS-75`
 - Linear URL: <https://linear.app/codewithshabib/issue/CWS-75/dev-align-agents-and-pr-template-with-branch-and-cws-title>
 - Generated: `2026-03-18`
-- Status: `In Review`
+- Status: `Done`
 
 ## Objective
 
@@ -28,6 +28,7 @@ Align `AGENTS.md` and PR template policy with create-pr traceability enforcement
 
 ## Completion Evidence
 
-- Open PR: <https://github.com/shabib87/shabib87.github.io/pull/38>
+- Completed at: `2026-03-18T18:18:26.625Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/38>
 - Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
 - Project: `[INFRA] Repo Process & Tooling`

--- a/docs/tasks/CWS-76.md
+++ b/docs/tasks/CWS-76.md
@@ -5,7 +5,7 @@
 - Linear issue: `CWS-76`
 - Linear URL: <https://linear.app/codewithshabib/issue/CWS-76/dev-backfill-completed-docstasks-files-and-refresh-agent-context>
 - Generated: `2026-03-18`
-- Status: `In Review`
+- Status: `Done`
 
 ## Objective
 
@@ -28,6 +28,7 @@ Backfill completed `docs/tasks` artifacts and refresh `docs/agent-context.md` ba
 
 ## Completion Evidence
 
-- Open PR: <https://github.com/shabib87/shabib87.github.io/pull/39>
+- Completed at: `2026-03-18T18:25:28.355Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/39>
 - Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
 - Project: `[INFRA] Repo Process & Tooling`

--- a/docs/tasks/CWS-77.md
+++ b/docs/tasks/CWS-77.md
@@ -5,7 +5,7 @@
 - Linear issue: `CWS-77`
 - Linear URL: <https://linear.app/codewithshabib/issue/CWS-77/dev-make-finalize-merge-stack-friendly-and-codify-startcloseout>
 - Generated: `2026-03-18`
-- Status: `In Progress`
+- Status: `Done`
 
 ## Objective
 
@@ -30,6 +30,8 @@ Make stack closeout merge flow Graphite-friendly by allowing rollout stack PR ba
 
 ## Completion Evidence
 
+- Completed at: `2026-03-18T18:28:26.307Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/40>
 - Branch: `codex/cws-77-finalize-merge-stack-friendly`
 - Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
 - Project: `[INFRA] Repo Process & Tooling`

--- a/docs/tasks/CWS-78.md
+++ b/docs/tasks/CWS-78.md
@@ -5,7 +5,7 @@
 - Linear issue: `CWS-78`
 - Linear URL: <https://linear.app/codewithshabib/issue/CWS-78/dev-clarify-graphite-vs-github-merge-paths-in-finalize-flow-and-harden>
 - Generated: `2026-03-18`
-- Status: `In Progress`
+- Status: `Done`
 
 ## Objective
 
@@ -29,5 +29,8 @@ Clarify stacked versus single-PR merge behavior so `scripts/finalize-merge.sh` i
 
 ## Completion Evidence
 
+- Completed at: `2026-03-18T18:51:45.020Z`
+- Merged PR: <https://github.com/shabib87/shabib87.github.io/pull/41>
 - Branch: `codex/cws-78-graphite-merge-flow-clarity`
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
 - Project: `[INFRA] Repo Process & Tooling`

--- a/docs/tasks/CWS-79.md
+++ b/docs/tasks/CWS-79.md
@@ -1,0 +1,41 @@
+# CWS-79 Task File
+
+## Source
+
+- Linear issue: `CWS-79`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-79/dev-harden-docstasks-as-immutable-context-snapshots-and-remove-status>
+- Captured from Linear at: `2026-03-18 19:10:08 EDT`
+- Status (Informational): `In Progress`
+
+## Objective
+
+Harden `docs/tasks` usage as immutable context snapshots and remove dual-status drift pressure.
+
+## Scope Snapshot
+
+- In scope: policy/docs/test updates that establish single-writer status ownership in Linear.
+- Out of scope: new dispatch automation (`codex-dispatch.yml`) or new Linear API integration.
+
+## Deterministic Acceptance Criteria
+
+1. `AGENTS.md` no longer treats local task-file status updates as a merge gate.
+2. A canonical `docs/tasks` template exists and codifies status as informational.
+3. Repo-flow guidance and master-plan wording align to single-writer status ownership.
+4. Workflow tests pass and confirm no task-status merge gate behavior.
+
+## Validation Commands
+
+- `ruby scripts/tests/create_pr_workflow_test.rb`
+- `ruby scripts/tests/finalize_merge_workflow_test.rb`
+- `make qa-local`
+
+## Evidence Pointers (Optional)
+
+- Branch: `codex/cws-79-task-context-single-writer`
+- Project: `[INFRA] Repo Process & Tooling`
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+
+## Single-Writer Rule
+
+- Linear is the mutable execution-status source of truth.
+- Local task-file `Status` is informational only and is not merge-gating.

--- a/docs/tasks/CWS-79.md
+++ b/docs/tasks/CWS-79.md
@@ -5,7 +5,6 @@
 - Linear issue: `CWS-79`
 - Linear URL: <https://linear.app/codewithshabib/issue/CWS-79/dev-harden-docstasks-as-immutable-context-snapshots-and-remove-status>
 - Captured from Linear at: `2026-03-18 19:10:08 EDT`
-- Status (Informational): `In Progress`
 
 ## Objective
 
@@ -38,4 +37,4 @@ Harden `docs/tasks` usage as immutable context snapshots and remove dual-status 
 ## Single-Writer Rule
 
 - Linear is the mutable execution-status source of truth.
-- Local task-file `Status` is informational only and is not merge-gating.
+- Do not maintain mutable status in task files; keep status changes in Linear only.

--- a/docs/tasks/CWS-79.md
+++ b/docs/tasks/CWS-79.md
@@ -18,7 +18,7 @@ Harden `docs/tasks` usage as immutable context snapshots and remove dual-status 
 ## Deterministic Acceptance Criteria
 
 1. `AGENTS.md` no longer treats local task-file status updates as a merge gate.
-2. A canonical `docs/tasks` template exists and codifies status as informational.
+2. A canonical `docs/tasks` template exists and forbids mutable local status fields.
 3. Repo-flow guidance and master-plan wording align to single-writer status ownership.
 4. Workflow tests pass and confirm no task-status merge gate behavior.
 

--- a/docs/tasks/TEMPLATE.md
+++ b/docs/tasks/TEMPLATE.md
@@ -1,0 +1,39 @@
+# CWS-XXX Task File Template
+
+## Source
+
+- Linear issue: `CWS-XXX`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-XXX>
+- Captured from Linear at: `YYYY-MM-DD HH:MM:SS TZ`
+- Status (Informational): `Backlog | Todo | In Progress | In Review | Done`
+
+## Objective
+
+Describe the intended outcome.
+
+## Scope Snapshot
+
+- In scope: list explicit in-scope changes.
+- Out of scope: list explicit exclusions.
+
+## Deterministic Acceptance Criteria
+
+1. Add measurable acceptance criterion.
+2. Add measurable acceptance criterion.
+
+## Validation Commands
+
+- `command-1`
+- `command-2`
+
+## Evidence Pointers (Optional)
+
+- PR: `https://github.com/<owner>/<repo>/pull/<id>`
+- Completed at: `YYYY-MM-DDTHH:MM:SSZ`
+- Cycle: `<cycle-id>`
+- Project: `<project-name>`
+
+## Single-Writer Rule
+
+- Linear is the mutable execution-status source of truth.
+- Local task-file `Status` is informational only and is not merge-gating.

--- a/docs/tasks/TEMPLATE.md
+++ b/docs/tasks/TEMPLATE.md
@@ -5,7 +5,6 @@
 - Linear issue: `CWS-XXX`
 - Linear URL: <https://linear.app/codewithshabib/issue/CWS-XXX>
 - Captured from Linear at: `YYYY-MM-DD HH:MM:SS TZ`
-- Status (Informational): `Backlog | Todo | In Progress | In Review | Done`
 
 ## Objective
 
@@ -36,4 +35,4 @@ Describe the intended outcome.
 ## Single-Writer Rule
 
 - Linear is the mutable execution-status source of truth.
-- Local task-file `Status` is informational only and is not merge-gating.
+- Do not maintain mutable status in task files; keep status changes in Linear only.

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -126,6 +126,7 @@ if [[ "$branch_mode" == "task" ]]; then
     exit 1
   fi
 
+  # Task files are local context snapshots. Gate only on existence; mutable status stays in Linear.
   task_file="$repo_root/docs/tasks/${issue_id}.md"
   if [[ ! -f "$task_file" ]]; then
     echo "error: missing required task file: docs/tasks/${issue_id}.md" >&2

--- a/scripts/tests/create_pr_workflow_test.rb
+++ b/scripts/tests/create_pr_workflow_test.rb
@@ -54,6 +54,11 @@ class CreatePrWorkflowTest < Minitest::Test
     assert_match(/missing required task file: docs\/tasks\/\$\{issue_id\}\.md/, script_body)
   end
 
+  def test_task_file_status_text_is_not_a_gate
+    refute_match(/task file status/i, script_body)
+    refute_match(/Completion Evidence/, script_body)
+  end
+
   def test_hard_fails_when_inferred_title_missing_issue_id
     assert_match(/inferred PR title must include \$\{issue_id\} for traceability/, script_body)
   end

--- a/scripts/tests/finalize_merge_workflow_test.rb
+++ b/scripts/tests/finalize_merge_workflow_test.rb
@@ -30,4 +30,9 @@ class FinalizeMergeWorkflowTest < Minitest::Test
   def test_stack_note_points_to_graphite_stack_merge
     assert_includes(script_body, "to merge the full stack, use Graphite web \"Merge stack\" or run: gt merge")
   end
+
+  def test_does_not_gate_on_task_file_status_text
+    refute_match(/task file status/i, script_body)
+    refute_match(/Completion Evidence/, script_body)
+  end
 end


### PR DESCRIPTION
## Summary

- docs(cws-79): task context single writer

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Linear Traceability

- Issue: https://linear.app/codewithshabib/issue/CWS-79

## Rollout Metadata

- plan_id: `governance-v3`
- branch_mode: `task`
- phase: `n/a`
- required_checks: `build,semgrep,rollout-governance`

## Validation

- `make qa-local`

## Affected Files

```text
.agents/skills/repo-flow/SKILL.md
.agents/skills/repo-flow/references/branch-pr-merge.md
AGENTS.md
docs/master-plan.md
docs/tasks/CWS-74.md
docs/tasks/CWS-75.md
docs/tasks/CWS-76.md
docs/tasks/CWS-77.md
docs/tasks/CWS-78.md
docs/tasks/CWS-79.md
docs/tasks/TEMPLATE.md
scripts/create-pr.sh
scripts/tests/create_pr_workflow_test.rb
scripts/tests/finalize_merge_workflow_test.rb
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
