### PR TITLE
feat(cws-20): make setup new mac bootstrap

### DIFF
--- a/.agents/skills/repo-flow/references/branch-pr-merge.md
+++ b/.agents/skills/repo-flow/references/branch-pr-merge.md
@@ -6,6 +6,8 @@
 - create a `codex/<type>-<slug>` branch
 - if the branch is created via `git checkout -b` (not `gt create`), run `gt track --parent main`
   before any `gt create`/`gt submit` command
+- on a pre-created task branch, use `gt modify --commit` to create commits; do not run `gt create`
+  from that branch because it creates a new branch and can violate branch-pattern gates.
 - keep work isolated to that branch
 - do not commit until `make qa-local` passes
 - if site-facing files changed, preview with `bundle exec jekyll serve` before commit

--- a/.agents/skills/repo-flow/references/branch-pr-merge.md
+++ b/.agents/skills/repo-flow/references/branch-pr-merge.md
@@ -26,3 +26,6 @@
 - integrate with rebase only for a linear history
 - delete the branch after integration
 - keep Linear issue and PR traceability links current; keep mutable status transitions in Linear only
+- if git/Graphite operations fail with `.git/index.lock` or sandbox write denial, escalate command
+  approval explicitly and retry; command prefix rules improve consistency but do not replace
+  filesystem permissions.

--- a/.codex/requirements.toml
+++ b/.codex/requirements.toml
@@ -1,0 +1,25 @@
+# CWS-20 admin-style requirements baseline for safer/easier agentic flow.
+# Reference: https://developers.openai.com/codex/config-reference
+
+# Restrictive approval/sandbox constraints.
+allowed_approval_policies = ["on-request", "granular"]
+allowed_sandbox_modes = ["workspace-write", "read-only"]
+allowed_web_search_modes = ["cached", "live"]
+
+[mcp_servers.context7.identity]
+command = "npx"
+
+[mcp_servers.linear.identity]
+url = "https://mcp.linear.app/mcp"
+
+[mcp_servers.graphite.identity]
+command = "/opt/homebrew/bin/gt"
+
+[rules]
+prefix_rules = [
+  # Require prompt for outbound-changing git actions.
+  { pattern = [{ token = "git" }, { any_of = ["push", "fetch", "pull"] }], decision = "prompt", justification = "Network or remote-state git operations must be explicitly approved." },
+  # Forbid high-risk destructive shortcuts.
+  { pattern = [{ token = "git" }, { token = "reset" }, { token = "--hard" }], decision = "forbidden", justification = "Prevent destructive history/worktree reset." },
+  { pattern = [{ token = "git" }, { token = "clean" }, { token = "-fdx" }], decision = "forbidden", justification = "Prevent destructive untracked-file deletion." }
+]

--- a/.codex/rules/execution-reliability.rules
+++ b/.codex/rules/execution-reliability.rules
@@ -1,27 +1,27 @@
 # CWS-20 execution reliability command policy.
 # Reference: https://developers.openai.com/codex/rules
-# These entries are command-governance hints only. Sandbox permissions still apply.
+# Keep this file in prefix_rule(...) form (Starlark), not TOML.
 
-[[command_rules]]
-pattern = ["git", "checkout"]
-decision = "prompt"
+# Prompt on state-mutating git lanes.
+prefix_rule(pattern=["git", "checkout"], decision="prompt")
+prefix_rule(pattern=["git", "rebase"], decision="prompt")
+prefix_rule(pattern=["git", "commit"], decision="prompt")
+prefix_rule(pattern=["git", "cherry-pick"], decision="prompt")
 
-[[command_rules]]
-pattern = ["git", "rebase"]
-decision = "prompt"
+# Prompt on Graphite mutating lanes.
+prefix_rule(pattern=["gt", "create"], decision="prompt")
+prefix_rule(pattern=["gt", "modify"], decision="prompt")
+prefix_rule(pattern=["gt", "submit"], decision="prompt")
+prefix_rule(pattern=["gt", "restack"], decision="prompt")
 
-[[command_rules]]
-pattern = ["git", "commit"]
-decision = "prompt"
-
-[[command_rules]]
-pattern = ["gt", "create"]
-decision = "prompt"
-
-[[command_rules]]
-pattern = ["gt", "modify"]
-decision = "prompt"
-
-[[command_rules]]
-pattern = ["gt", "submit"]
-decision = "prompt"
+# Hard-block destructive git shortcuts.
+prefix_rule(
+    pattern=["git", "reset", "--hard"],
+    decision="forbidden",
+    justification="Blocked to avoid irreversible history/worktree loss."
+)
+prefix_rule(
+    pattern=["git", "clean", "-fdx"],
+    decision="forbidden",
+    justification="Blocked to avoid deleting untracked files/directories."
+)

--- a/.codex/rules/execution-reliability.rules
+++ b/.codex/rules/execution-reliability.rules
@@ -2,6 +2,13 @@
 # Reference: https://developers.openai.com/codex/rules
 # Keep this file in prefix_rule(...) form (Starlark), not TOML.
 
+# Fast safe lanes for read-only/local inspection commands.
+prefix_rule(pattern=["git", "status"], decision="allow")
+prefix_rule(pattern=["git", "diff"], decision="allow")
+prefix_rule(pattern=["git", "log"], decision="allow")
+prefix_rule(pattern=["rg"], decision="allow")
+prefix_rule(pattern=["gh", "pr", "view"], decision="allow")
+
 # Prompt on state-mutating git lanes.
 prefix_rule(pattern=["git", "checkout"], decision="prompt")
 prefix_rule(pattern=["git", "rebase"], decision="prompt")

--- a/.codex/rules/execution-reliability.rules
+++ b/.codex/rules/execution-reliability.rules
@@ -1,0 +1,27 @@
+# CWS-20 execution reliability command policy.
+# Reference: https://developers.openai.com/codex/rules
+# These entries are command-governance hints only. Sandbox permissions still apply.
+
+[[command_rules]]
+pattern = ["git", "checkout"]
+decision = "prompt"
+
+[[command_rules]]
+pattern = ["git", "rebase"]
+decision = "prompt"
+
+[[command_rules]]
+pattern = ["git", "commit"]
+decision = "prompt"
+
+[[command_rules]]
+pattern = ["gt", "create"]
+decision = "prompt"
+
+[[command_rules]]
+pattern = ["gt", "modify"]
+decision = "prompt"
+
+[[command_rules]]
+pattern = ["gt", "submit"]
+decision = "prompt"

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,7 @@
 brew "gh"
 brew "python"
+brew "rbenv"
+brew "ruby-build"
+brew "semgrep"
+brew "vale"
+brew "cspell"

--- a/docs/agent-context.md
+++ b/docs/agent-context.md
@@ -72,6 +72,20 @@ This file is a bounded cache for agent continuity.
 
 ## Recent Completions
 
+- [x] Captured `CWS-20` additive execution-reliability policy: added
+  `.codex/rules/execution-reliability.rules` command-prefix prompts for git/Graphite write lanes,
+  and documented `.git/index.lock` escalation fallback in
+  `.agents/skills/repo-flow/references/branch-pr-merge.md`.
+- [x] Removed post-setup shell fragility for repo Ruby usage: added shared
+  `activate_repo_ruby` helper in `scripts/lib/tooling.sh` and wired
+  `scripts/run-codex-checks.sh` + `scripts/run-checks.sh` to require the repo Ruby version
+  automatically; added coverage in `scripts/tests/repo_ruby_activation_test.rb`.
+- [x] `CWS-20` setup bootstrap hardened: `Brewfile` now includes `rbenv`, `ruby-build`,
+  `semgrep`, `vale`, and `cspell`; `scripts/setup-dev.sh` now provisions required repo Ruby
+  through `rbenv` without `eval`; and `scripts/tests/setup_dev_bootstrap_test.rb` added to pin
+  the setup contract.
+- [x] Started `CWS-20` pickup: created immutable task snapshot `docs/tasks/CWS-20.md`
+  from current Linear issue context (`2026-03-18 EDT`) to clear missing local task-file evidence.
 - [x] Aligned PR submit flow to Graphite docs for non-interactive usage by adding `--publish` to
   `gt submit --stack --no-interactive` paths in `scripts/create-pr.sh` (initial submit + retry
   paths), with test coverage updates in `scripts/tests/create_pr_workflow_test.rb`.

--- a/docs/agent-context.md
+++ b/docs/agent-context.md
@@ -72,6 +72,9 @@ This file is a bounded cache for agent continuity.
 
 ## Recent Completions
 
+- [x] Converted `.codex/rules/execution-reliability.rules` to valid Codex Starlark
+  `prefix_rule(...)` syntax and added `.codex/requirements.toml` with restrictive prefix rules
+  plus MCP allowlist entries for `context7`, `linear`, and `graphite`.
 - [x] Captured `CWS-20` additive execution-reliability policy: added
   `.codex/rules/execution-reliability.rules` command-prefix prompts for git/Graphite write lanes,
   and documented `.git/index.lock` escalation fallback in

--- a/docs/tasks/CWS-20.md
+++ b/docs/tasks/CWS-20.md
@@ -1,0 +1,38 @@
+# CWS-20 Task File
+
+## Source
+
+- Linear issue: `CWS-20`
+- Linear URL: <https://linear.app/codewithshabib/issue/CWS-20/dev-implement-make-setup-new-mac-bootstrap>
+- Captured from Linear at: `2026-03-18 21:47:37 EDT`
+
+## Objective
+
+Implement `make setup` for deterministic local bootstrap on macOS.
+
+## Scope Snapshot
+
+- In scope: install required tools and environment prerequisites; run dependency/bootstrap steps and verification checks.
+- Out of scope: CI-only setup logic.
+
+## Deterministic Acceptance Criteria
+
+1. Repository setup path is reachable via `make setup` and includes required bootstrap/install steps for local macOS development.
+2. Setup-related commands are discoverable in repository workflow files (`Makefile` and setup scripts) with expected tool/bootstrap references.
+3. Local quality gate passes after setup changes are applied.
+
+## Validation Commands
+
+- `rg -n "setup|rbenv|ruby-build|vale|markdownlint|cspell|semgrep|install-hooks" Makefile`
+- `make qa-local`
+
+## Evidence Pointers (Optional)
+
+- Gate type: `PR_REQUIRED`
+- Cycle: `7ef11bc3-f086-40a6-afd9-256b27df384d`
+- Project: `[INFRA] Repo Process & Tooling`
+
+## Single-Writer Rule
+
+- Linear is the mutable execution-status source of truth.
+- Do not maintain mutable status in task files; keep status changes in Linear only.

--- a/scripts/lib/tooling.sh
+++ b/scripts/lib/tooling.sh
@@ -18,6 +18,17 @@ repo_ruby_version() {
   tr -d '[:space:]' < "$repo_root/.ruby-version"
 }
 
+activate_repo_ruby() {
+  local required
+  required="$(repo_ruby_version)"
+
+  if command -v rbenv >/dev/null 2>&1 || [[ -x "${HOME}/.rbenv/bin/rbenv" ]]; then
+    export RBENV_ROOT="${RBENV_ROOT:-$HOME/.rbenv}"
+    export PATH="$RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH"
+    export RBENV_VERSION="$required"
+  fi
+}
+
 require_repo_ruby() {
   local expected actual
   expected="$(repo_ruby_version)"

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -6,6 +6,8 @@ cd "$repo_root"
 
 # shellcheck disable=SC1091
 . "$repo_root/scripts/lib/tooling.sh"
+activate_repo_ruby
+require_repo_ruby || exit 1
 
 export BUNDLE_PATH="$repo_root/vendor/bundle"
 export BUNDLE_FROZEN="true"

--- a/scripts/run-codex-checks.sh
+++ b/scripts/run-codex-checks.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+# shellcheck disable=SC1091
+. "$repo_root/scripts/lib/tooling.sh"
+activate_repo_ruby
+require_repo_ruby || exit 1
+
 phase="${PHASE:-}"
 if [[ -z "$phase" ]]; then
   branch="$(git branch --show-current 2>/dev/null || true)"

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -36,6 +36,52 @@ ensure_brew_package() {
   brew install "$formula"
 }
 
+ensure_repo_ruby_with_rbenv() {
+  local required actual rbenv_bin
+  required="$(repo_ruby_version)"
+
+  if command -v ruby >/dev/null 2>&1; then
+    actual="$(ruby -e 'print RUBY_VERSION')"
+    if [[ "$actual" == "$required" ]]; then
+      return 0
+    fi
+    echo "info: ruby $required required, found $actual"
+  else
+    echo "info: ruby $required required and not found on PATH"
+  fi
+
+  if ! command -v rbenv >/dev/null 2>&1; then
+    return 1
+  fi
+
+  if ! command -v ruby-build >/dev/null 2>&1; then
+    return 1
+  fi
+
+  export RBENV_ROOT="${RBENV_ROOT:-$HOME/.rbenv}"
+  rbenv_bin="$(command -v rbenv)"
+  export PATH="$RBENV_ROOT/bin:$RBENV_ROOT/shims:$PATH"
+
+  if ! "$rbenv_bin" versions --bare | grep -Fxq "$required"; then
+    echo "info: installing ruby $required via rbenv"
+    "$rbenv_bin" install -s "$required"
+  fi
+
+  "$rbenv_bin" local "$required"
+  "$rbenv_bin" rehash
+
+  if ! actual="$(RBENV_VERSION="$required" "$rbenv_bin" exec ruby -e 'print RUBY_VERSION' 2>/dev/null)"; then
+    return 1
+  fi
+
+  if [[ "$actual" != "$required" ]]; then
+    return 1
+  fi
+
+  export RBENV_VERSION="$required"
+  return 0
+}
+
 install_repo_pre_commit() {
   local pre_commit_bin
   pre_commit_bin="$(repo_pre_commit_bin)"
@@ -62,11 +108,20 @@ require_cmd() {
   fi
 }
 
-require_cmd ruby "Install Ruby via your preferred package manager."
 require_cmd git "Install Git from https://git-scm.com/downloads"
 
-if [[ "$missing" -eq 0 ]]; then
-  require_repo_ruby || exit 1
+if ! ensure_brew_package rbenv rbenv; then
+  require_cmd rbenv "Install rbenv, e.g. brew install rbenv"
+fi
+
+if ! ensure_brew_package ruby-build ruby-build; then
+  require_cmd ruby-build "Install ruby-build, e.g. brew install ruby-build"
+fi
+
+if ! ensure_repo_ruby_with_rbenv; then
+  echo "error: unable to provision required ruby $(repo_ruby_version)" >&2
+  echo "hint: install rbenv + ruby-build, then rerun make setup" >&2
+  missing=1
 fi
 
 if ! ensure_bundler; then
@@ -82,6 +137,18 @@ fi
 
 if ! ensure_brew_package python3 python; then
   require_cmd python3 "Install Python 3, e.g. brew install python"
+fi
+
+if ! ensure_brew_package semgrep semgrep; then
+  require_cmd semgrep "Install Semgrep, e.g. brew install semgrep"
+fi
+
+if ! ensure_brew_package vale vale; then
+  require_cmd vale "Install Vale, e.g. brew install vale"
+fi
+
+if ! ensure_brew_package cspell cspell; then
+  require_cmd cspell "Install cspell, e.g. brew install cspell"
 fi
 
 if ! install_repo_pre_commit; then

--- a/scripts/tests/execution_reliability_rules_test.rb
+++ b/scripts/tests/execution_reliability_rules_test.rb
@@ -5,6 +5,7 @@ require "minitest/autorun"
 
 class ExecutionReliabilityRulesTest < Minitest::Test
   RULES_PATH = File.expand_path("../../.codex/rules/execution-reliability.rules", __dir__)
+  REQUIREMENTS_PATH = File.expand_path("../../.codex/requirements.toml", __dir__)
   REPO_FLOW_REF_PATH = File.expand_path("../../.agents/skills/repo-flow/references/branch-pr-merge.md", __dir__)
 
   def rules_body
@@ -17,13 +18,26 @@ class ExecutionReliabilityRulesTest < Minitest::Test
 
   def test_rules_file_exists_with_git_and_gt_write_command_prefix_rules
     assert(File.file?(RULES_PATH), "expected rules file at #{RULES_PATH}")
-    assert_match(/pattern = \["git", "checkout"\]/, rules_body)
-    assert_match(/pattern = \["git", "rebase"\]/, rules_body)
-    assert_match(/pattern = \["git", "commit"\]/, rules_body)
-    assert_match(/pattern = \["gt", "create"\]/, rules_body)
-    assert_match(/pattern = \["gt", "modify"\]/, rules_body)
-    assert_match(/pattern = \["gt", "submit"\]/, rules_body)
-    assert_match(/decision = "prompt"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["git", "checkout"\],\s*decision="prompt"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["git", "rebase"\],\s*decision="prompt"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["git", "commit"\],\s*decision="prompt"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["gt", "create"\],\s*decision="prompt"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["gt", "modify"\],\s*decision="prompt"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["gt", "submit"\],\s*decision="prompt"/, rules_body)
+  end
+
+  def test_requirements_file_enforces_mcp_allowlist_for_configured_servers
+    assert(File.file?(REQUIREMENTS_PATH), "expected requirements file at #{REQUIREMENTS_PATH}")
+    body = File.read(REQUIREMENTS_PATH)
+
+    assert_match(/\[mcp_servers\.context7\.identity\]/, body)
+    assert_match(/command = "npx"/, body)
+
+    assert_match(/\[mcp_servers\.linear\.identity\]/, body)
+    assert_match(%r{url = "https://mcp\.linear\.app/mcp"}, body)
+
+    assert_match(/\[mcp_servers\.graphite\.identity\]/, body)
+    assert_match(%r{command = "/opt/homebrew/bin/gt"}, body)
   end
 
   def test_repo_flow_reference_documents_index_lock_escalation_fallback

--- a/scripts/tests/execution_reliability_rules_test.rb
+++ b/scripts/tests/execution_reliability_rules_test.rb
@@ -18,6 +18,11 @@ class ExecutionReliabilityRulesTest < Minitest::Test
 
   def test_rules_file_exists_with_git_and_gt_write_command_prefix_rules
     assert(File.file?(RULES_PATH), "expected rules file at #{RULES_PATH}")
+    assert_match(/prefix_rule\(\s*pattern=\["git", "status"\],\s*decision="allow"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["git", "diff"\],\s*decision="allow"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["git", "log"\],\s*decision="allow"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["rg"\],\s*decision="allow"/, rules_body)
+    assert_match(/prefix_rule\(\s*pattern=\["gh", "pr", "view"\],\s*decision="allow"/, rules_body)
     assert_match(/prefix_rule\(\s*pattern=\["git", "checkout"\],\s*decision="prompt"/, rules_body)
     assert_match(/prefix_rule\(\s*pattern=\["git", "rebase"\],\s*decision="prompt"/, rules_body)
     assert_match(/prefix_rule\(\s*pattern=\["git", "commit"\],\s*decision="prompt"/, rules_body)

--- a/scripts/tests/execution_reliability_rules_test.rb
+++ b/scripts/tests/execution_reliability_rules_test.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "minitest/autorun"
+
+class ExecutionReliabilityRulesTest < Minitest::Test
+  RULES_PATH = File.expand_path("../../.codex/rules/execution-reliability.rules", __dir__)
+  REPO_FLOW_REF_PATH = File.expand_path("../../.agents/skills/repo-flow/references/branch-pr-merge.md", __dir__)
+
+  def rules_body
+    @rules_body ||= File.read(RULES_PATH)
+  end
+
+  def repo_flow_ref_body
+    @repo_flow_ref_body ||= File.read(REPO_FLOW_REF_PATH)
+  end
+
+  def test_rules_file_exists_with_git_and_gt_write_command_prefix_rules
+    assert(File.file?(RULES_PATH), "expected rules file at #{RULES_PATH}")
+    assert_match(/pattern = \["git", "checkout"\]/, rules_body)
+    assert_match(/pattern = \["git", "rebase"\]/, rules_body)
+    assert_match(/pattern = \["git", "commit"\]/, rules_body)
+    assert_match(/pattern = \["gt", "create"\]/, rules_body)
+    assert_match(/pattern = \["gt", "modify"\]/, rules_body)
+    assert_match(/pattern = \["gt", "submit"\]/, rules_body)
+    assert_match(/decision = "prompt"/, rules_body)
+  end
+
+  def test_repo_flow_reference_documents_index_lock_escalation_fallback
+    assert_match(/\.git\/index\.lock/, repo_flow_ref_body)
+    assert_match(/escalat/i, repo_flow_ref_body)
+  end
+end

--- a/scripts/tests/execution_reliability_rules_test.rb
+++ b/scripts/tests/execution_reliability_rules_test.rb
@@ -29,5 +29,7 @@ class ExecutionReliabilityRulesTest < Minitest::Test
   def test_repo_flow_reference_documents_index_lock_escalation_fallback
     assert_match(/\.git\/index\.lock/, repo_flow_ref_body)
     assert_match(/escalat/i, repo_flow_ref_body)
+    assert_match(/use `gt modify --commit`/, repo_flow_ref_body)
+    assert_match(/do not run `gt create`/, repo_flow_ref_body)
   end
 end

--- a/scripts/tests/repo_ruby_activation_test.rb
+++ b/scripts/tests/repo_ruby_activation_test.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "minitest/autorun"
+
+class RepoRubyActivationTest < Minitest::Test
+  TOOLING_PATH = File.expand_path("../lib/tooling.sh", __dir__)
+  CODEX_CHECK_PATH = File.expand_path("../run-codex-checks.sh", __dir__)
+  CHECK_PATH = File.expand_path("../run-checks.sh", __dir__)
+
+  def tooling_body
+    @tooling_body ||= File.read(TOOLING_PATH)
+  end
+
+  def codex_check_body
+    @codex_check_body ||= File.read(CODEX_CHECK_PATH)
+  end
+
+  def check_body
+    @check_body ||= File.read(CHECK_PATH)
+  end
+
+  def test_tooling_exposes_repo_ruby_activation_helper
+    assert_match(/activate_repo_ruby\(\)/, tooling_body)
+    assert_match(/export PATH="\$RBENV_ROOT\/shims:\$RBENV_ROOT\/bin:\$PATH"/, tooling_body)
+    assert_match(/export RBENV_VERSION="\$required"/, tooling_body)
+  end
+
+  def test_codex_checks_activates_and_requires_repo_ruby
+    assert_match(/activate_repo_ruby/, codex_check_body)
+    assert_match(/require_repo_ruby \|\| exit 1/, codex_check_body)
+  end
+
+  def test_run_checks_activates_and_requires_repo_ruby
+    assert_match(/activate_repo_ruby/, check_body)
+    assert_match(/require_repo_ruby \|\| exit 1/, check_body)
+  end
+end

--- a/scripts/tests/setup_dev_bootstrap_test.rb
+++ b/scripts/tests/setup_dev_bootstrap_test.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "minitest/autorun"
+
+class SetupDevBootstrapTest < Minitest::Test
+  SCRIPT_PATH = File.expand_path("../setup-dev.sh", __dir__)
+  BREWFILE_PATH = File.expand_path("../../Brewfile", __dir__)
+
+  def script_body
+    @script_body ||= File.read(SCRIPT_PATH)
+  end
+
+  def brewfile
+    @brewfile ||= File.read(BREWFILE_PATH)
+  end
+
+  def test_setup_bootstraps_rbenv_and_ruby_build_when_brew_is_available
+    assert_match(/ensure_brew_package rbenv rbenv/, script_body)
+    assert_match(/ensure_brew_package ruby-build ruby-build/, script_body)
+    assert_match(/ensure_repo_ruby_with_rbenv/, script_body)
+    assert_match(/install -s "\$required"/, script_body)
+  end
+
+  def test_brewfile_includes_required_bootstrap_tooling
+    %w[gh python rbenv ruby-build semgrep vale cspell].each do |formula|
+      assert_includes(brewfile, %(brew "#{formula}"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- feat(cws-20): make setup new mac bootstrap

## Why

- Standardize the change behind the repo's branch and PR workflow.

## Linear Traceability

- Issue: https://linear.app/codewithshabib/issue/CWS-20

## Rollout Metadata

- plan_id: `governance-v3`
- branch_mode: `task`
- phase: `n/a`
- required_checks: `build,semgrep,rollout-governance`

## Validation

- `make qa-local`

## Affected Files

```text
.agents/skills/repo-flow/references/branch-pr-merge.md
.codex/requirements.toml
.codex/rules/execution-reliability.rules
Brewfile
docs/agent-context.md
docs/tasks/CWS-20.md
scripts/lib/tooling.sh
scripts/run-checks.sh
scripts/run-codex-checks.sh
scripts/setup-dev.sh
scripts/tests/execution_reliability_rules_test.rb
scripts/tests/repo_ruby_activation_test.rb
scripts/tests/setup_dev_bootstrap_test.rb
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Full local QA gate passed
- Diff reviewed
- No private drafts or secrets included
