### PR TITLE
feat(cws-82): add CLAUDE.md and update AGENTS.md for dual-platform pivot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,8 @@ Reference canonical definitions in `docs/master-plan.md` and `docs/sop.md`.
 
 ## Task-File Convention
 
-- Task branches use `codex/cws-<id>-<slug>`.
+- Task branches use `codex/cws-<id>-<slug>`. (The `codex/` prefix is a repo convention, not a
+  platform restriction.)
 - `docs/tasks/CWS-<id>.md` is required before PR creation.
 - Task files are immutable context snapshots.
 - Do not store mutable status fields in task files; Linear is the single mutable status owner.
@@ -124,7 +125,7 @@ Test-first policy:
 
 ## Instruction-Based Boundary Caveat
 
-Codex boundary control is instruction-based, not hard sandbox partitioning per role.
+Agent boundary control is instruction-based, not hard sandbox partitioning per role.
 
 - `MUST NOT` boundaries reduce risk but are not a platform-enforced ACL.
 - Mitigate with scoped tasks, validation gates, self-audit, and PR review discipline.
@@ -145,6 +146,16 @@ If there are no significant issues, state: `No high-impact findings.`
 - Use Context7 or first-party docs for version-sensitive behavior.
 - Use repo-local skills first when task shape matches a skill.
 - Keep `AGENTS.md` small; place repeatable procedures in skills and references.
+
+## Platform Applicability
+
+This contract applies to all agent execution platforms used with this repository, including
+OpenAI Codex and Anthropic Claude Code. Platform-specific mechanics are documented in:
+
+- Codex: `.codex/` directory, `docs/sop.md`
+- Claude Code: `CLAUDE.md`
+
+The rules in this file override any platform-specific defaults.
 
 ## Bash Security Baseline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# Claude Code Project Instructions
+
+This file is the Claude Code session-start instruction surface for this repository.
+
+## Execution Contract
+
+`AGENTS.md` is the authoritative execution contract. All rules in `AGENTS.md` apply equally to
+Claude Code sessions. If anything in this file conflicts with `AGENTS.md`, follow `AGENTS.md`.
+
+## Agent Role System
+
+Nine execution agent roles are defined for this repository:
+
+- `team-lead` (orchestrator) — plans, delegates, synthesizes
+- `developer` — implements scoped changes
+- `researcher` — read-only information gathering
+- `writer` — content creation
+- `editor` — content quality and fixes
+- `fact-checker` — source verification
+- `seo-expert` — discoverability and SEO
+- `publisher-release` — packaging and release flow
+- `historical-post-editor` — legacy content refresh
+
+Role definitions live in `.agents/roles/<name>/soul.md` and `instructions.md` (shared across
+platforms; created by CWS-23 — not yet present). Each role has a One Piece character identity
+defined in `docs/master-plan.md`.
+
+## Subagent Dispatch
+
+When spawning a subagent via the `Agent` tool:
+
+- Read the appropriate role's `soul.md` and `instructions.md` from `.agents/roles/<name>/` and
+  incorporate into the agent prompt (once role files exist).
+- Use `isolation: "worktree"` for read-heavy or risky work.
+- Max depth: agents do not spawn sub-agents. Only the orchestrator delegates.
+- For parallel work, batch multiple `Agent` tool calls in a single message.
+- Concurrency guidance: prefer 3 or fewer parallel agents; batch if more lanes are needed.
+
+## Context and Memory
+
+- Read `docs/agent-context.md` at task start; update when meaningful context changes.
+- Reference `docs/sop.md` for orchestration patterns and platform capabilities.
+- Reference `docs/master-plan.md` for architecture and backlog context.
+- Claude Code's file-based memory system (`~/.claude/`) is available for cross-session continuity.
+
+## Skills
+
+- Skills at `.agents/skills/` follow the agentskills.io open standard.
+- Read `SKILL.md` files directly when a skill matches the task shape.
+- Ignore `agents/openai.yaml` files within skills (Codex-specific extension).
+
+## MCP
+
+- Linear and Context7 MCP servers are available.
+- Claude Code MCP configuration is managed in Claude Code's own settings.
+
+## Task Pickup
+
+- Same queue resolution as `AGENTS.md`: Linear first, local second.
+- Same branch convention: `codex/cws-<id>-<slug>` (the `codex/` prefix is a repo convention,
+  not a platform restriction).
+- Same task file requirement: `docs/tasks/CWS-<id>.md` before PR creation.
+
+## Graphite
+
+- Use `gt` CLI for stacked PR lifecycle (`create`, `modify`, `submit`, `stack`).
+- Use `gh` CLI for GitHub object operations (checks, labels, comments, PR metadata).
+
+## Validation
+
+- `make qa-local` is the required local release gate.
+- `make create-pr TYPE=...` standardizes PR metadata packaging.
+- `make finalize-merge PR=...` standardizes rebase-only integration closeout.


### PR DESCRIPTION
## Summary
- Creates `CLAUDE.md` as the Claude Code session-start instruction surface
- Updates `AGENTS.md` with platform applicability section, platform-neutral boundary language, and branch convention annotation
- Core contract layer of the dual-platform pivot (CWS-82)

Closes CWS-82

## Test plan
- [x] `CLAUDE.md` exists, under 2000 tokens, references valid paths
- [x] `AGENTS.md` has platform applicability section
- [x] `make qa-local` passes