### PR TITLE
chore(CWS-93): harden repo-flow skill per CWS-82 lessons and agentskills.io

### DIFF
--- a/.agents/skills/repo-flow/SKILL.md
+++ b/.agents/skills/repo-flow/SKILL.md
@@ -52,7 +52,7 @@ Use this skill for repository workflow mechanics only.
 ## Done Criteria
 
 - Work is packaged in a PR with clean commits.
-- Required local checks have passed.
+- Required local checks have passed (see Validation Loop for execution protocol).
 - Integration path is explicit, rebase-only, and policy-compliant.
 
 ## Gotchas
@@ -79,19 +79,20 @@ Use this skill for repository workflow mechanics only.
 - If setting `In Progress` or cycle linkage fails, stop execution and report the blocker.
 - MUST NOT use `gh pr merge` directly — use `make finalize-merge PR=...`.
 - MUST NOT use `gt sync --force` to reconcile after partial stack merges.
-- For stacks, MUST use `gt merge` or Graphite web, not individual PR merges.
+- For full-stack merges, use `gt merge` or Graphite web. Single-PR merges from a stack via `make finalize-merge PR=...` are allowed but only merge that PR — retarget children manually if needed.
 - MUST NOT create bulk commits — use atomic commits (one logical change per commit).
 
 ## Validation Loop
 
-1. Run `make qa-local`. If it fails, fix issues and re-run.
-2. Do not commit until `make qa-local` passes.
+1. Run `make qa-local`. If it passes, proceed to commit.
+2. If it fails, diagnose the issue (invoke `superpowers:systematic-debugging` if available), fix, and re-run.
 3. If `make qa-local` fails twice consecutively, stop and report (per AGENTS.md loop safety).
-4. If `make qa-local` fails, invoke `superpowers:systematic-debugging` to diagnose.
+4. Do not commit until `make qa-local` passes.
 
 ## Cross-Skill References
 
-These are Claude Code plugin skills — MUST be invoked during repo-flow execution:
+These are Claude Code plugin skills — SHOULD be invoked if available during repo-flow execution.
+They are platform-provided (not repo-local), so agents on other platforms may skip them.
 
 - `superpowers:verification-before-completion` — invoke before claiming work is done.
 - `superpowers:systematic-debugging` — invoke if `make qa-local` fails.

--- a/.agents/skills/repo-flow/SKILL.md
+++ b/.agents/skills/repo-flow/SKILL.md
@@ -55,6 +55,15 @@ Use this skill for repository workflow mechanics only.
 - Required local checks have passed.
 - Integration path is explicit, rebase-only, and policy-compliant.
 
+## Gotchas
+
+- `gt sync --force` after partial stack merges deletes branches and closes PRs. Never use it to
+  reconcile a partially merged stack.
+- `gh pr merge` directly bypasses validation gates in `make finalize-merge`. Always use
+  `make finalize-merge PR=...` for single-PR merges.
+- For Graphite stacks, `make finalize-merge` only merges one PR and does not manage Graphite
+  metadata or retarget children. Use `gt merge` or Graphite web for full-stack merges.
+
 ## Rules
 
 - Start repo-changing work from `main` on a fresh `cws/*` branch.
@@ -68,6 +77,25 @@ Use this skill for repository workflow mechanics only.
 - Use Linear as the mutable execution-status source of truth; keep task files focused on execution brief and evidence pointers.
 - Before repo edits on a task issue, Linear state MUST be `In Progress` and cycle linkage MUST be present.
 - If setting `In Progress` or cycle linkage fails, stop execution and report the blocker.
+- MUST NOT use `gh pr merge` directly — use `make finalize-merge PR=...`.
+- MUST NOT use `gt sync --force` to reconcile after partial stack merges.
+- For stacks, MUST use `gt merge` or Graphite web, not individual PR merges.
+- MUST NOT create bulk commits — use atomic commits (one logical change per commit).
+
+## Validation Loop
+
+1. Run `make qa-local`. If it fails, fix issues and re-run.
+2. Do not commit until `make qa-local` passes.
+3. If `make qa-local` fails twice consecutively, stop and report (per AGENTS.md loop safety).
+4. If `make qa-local` fails, invoke `superpowers:systematic-debugging` to diagnose.
+
+## Cross-Skill References
+
+These are Claude Code plugin skills — MUST be invoked during repo-flow execution:
+
+- `superpowers:verification-before-completion` — invoke before claiming work is done.
+- `superpowers:systematic-debugging` — invoke if `make qa-local` fails.
+- `commit-commands:commit` — invoke for commit creation conventions.
 
 ## Trigger Quality Check
 

--- a/.agents/skills/repo-flow/SKILL.md
+++ b/.agents/skills/repo-flow/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: repo-flow
-description: Use this skill when the user asks to start, validate, package, or integrate repository changes in this repo using its scripted workflow (`make qa-local`, `make create-pr`, `make finalize-merge`) and policy gates (branch naming, task file presence, Linear traceability, rebase-only integration). Use it even when requested indirectly ("open a PR", "finish merge", "prep branch"). Do not use for editorial drafting or content-only edits that do not involve repo workflow mechanics, and do not use for generic git advice outside this repository.
+description: >-
+  Use this skill when the user asks to start, validate, package, or integrate repository changes
+  in this repo using its scripted workflow (make qa-local, make create-pr, make finalize-merge)
+  and policy gates (branch naming, task file presence, Linear traceability, rebase-only
+  integration). Use it even when requested indirectly ("open a PR", "finish merge", "prep
+  branch"). Do not use for editorial drafting or content-only edits that do not involve repo
+  workflow mechanics, and do not use for generic git advice outside this repository.
 ---
 
 # Repo Flow
@@ -56,6 +62,9 @@ Use this skill for repository workflow mechanics only.
 - Integration path is explicit, rebase-only, and policy-compliant.
 
 ## Gotchas
+
+Known failure modes specific to this workflow. Other skills should adopt a similar section when
+non-obvious failure modes accumulate from real incidents.
 
 - `gt sync --force` after partial stack merges deletes branches and closes PRs. Never use it to
   reconcile a partially merged stack.


### PR DESCRIPTION
## Summary

- Add gotchas, MUST NOT rules, validation loop, and cross-skill references to the `repo-flow` skill SKILL.md.

## Why

- CWS-93 backlog hygiene: capture CWS-82 lessons learned and align skill documentation with agentskills.io conventions.

## Linear Traceability

- Parent issue: https://linear.app/codewithshabib/issue/CWS-81
- This issue: https://linear.app/codewithshabib/issue/CWS-93

## Validation

- `make qa-local` ✅

## Affected Files

```text
.agents/skills/repo-flow/SKILL.md
```

## Affected URLs

```text
(none identified)
```

## Self-review Notes

- Risk assessment: Low — skill documentation only
- Backward compatibility notes: None